### PR TITLE
Fix Forgot Password link from login controller

### DIFF
--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.m
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.m
@@ -114,7 +114,12 @@
 #pragma mark UIWebview delegate methods
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
-    if ([request.URL.absoluteString hasPrefix:[self.oauthServer absoluteString]])
+    if ([request.URL.absoluteString hasSuffix:@"forgot/"])
+    {
+        [[UIApplication sharedApplication] openURL:request.URL];
+        return NO;
+    }
+    else if ([request.URL.absoluteString hasPrefix:[self.oauthServer absoluteString]])
     {
         return YES;
     }


### PR DESCRIPTION
There’s a “Forgot your password?” link on the login page, but the `MendeleyLoginViewController` is currently blocking it (the web view delegate returns `NO` to the `shouldStartLoadWithRequest:` method). I believe it also affects the official Mendeley iOS app.

The easiest solution, I think, is to forward that request to Safari. We could also load it inside the web view itself, but then we’d need to take care of things like navigation (back/forward).

![ios simulator screen shot jul 15 2015 2 22 29 pm](https://cloud.githubusercontent.com/assets/886053/8698297/07660736-2afd-11e5-940b-c07f66282bd4.png)
