### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# How to submit code
+
+This is an early-bird version of the MendeleyKit. We welcome your thoughts and suggestions. If you would like to make active contributions, e.g. code changes/additions,
+
+- code submissions should only be made to Development branch via pull requests. 
+- you may create your own subbranches from Development and submit to it at will. However, if you want to merge it into Development then you would need to create a pull request
+- Note: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!


### PR DESCRIPTION
Messing up with my previous pull-request made me realise that GitHub [suggests](https://github.com/blog/1184-contributing-guidelines) having a dedicated file, that will appear whenever someone tries to create a new PR. 

The content comes from the current README.