### PR TITLE
Fix creating error with no localized description

### DIFF
--- a/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+MendeleyError.m
+++ b/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+MendeleyError.m
@@ -25,11 +25,13 @@
 
 + (id)errorWithCode:(MendeleyErrorCode)code localizedDescription:(NSString *)localizedDescription
 {
-    if (nil == localizedDescription)
+    NSDictionary *userInfo = nil;
+
+    if (nil != localizedDescription)
     {
-        localizedDescription = MendeleyErrorUnknown;
+        userInfo = @{ NSLocalizedDescriptionKey: localizedDescription };
     }
-    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: localizedDescription };
+
     return [[self class] errorWithDomain:kMendeleyErrorDomain code:code userInfo:userInfo];
 }
 


### PR DESCRIPTION
The Xcode “Analyse” tool helped me discover that bug.

This method tests if `localizedDescription` is `nil` before using it in a dictionary. That’s great, but the method used to give it `MendeleyErrorUnknown` as a default value. There must be some confusion, because that constant is a `NSInteger`, not a `NSString`, that should be used for error codes, not error descriptions. Worse, this constant equals `0`, so the string effectively gets a `nil` value, which would precisely crash when used in a dictionary.