### PR TITLE
Fix annotation coder initializer when super fails

### DIFF
--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.m
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.m
@@ -142,8 +142,8 @@
             _box = NSRectToCGRect([rectValue rectValue]);
 #endif
         }
+        _page = [decoder decodeObjectOfClass:[self class] forKey:kMendeleyJSONPage];
     }
-    _page = [decoder decodeObjectOfClass:[self class] forKey:kMendeleyJSONPage];
     return self;
 }
 


### PR DESCRIPTION
Another small bug found by Xcode “Analyse” tool.

> MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.m:146:11
> Access to instance variable '_page' results in a dereference of a null pointer (loaded from variable 'self')

It would only be a problem if `[super init]` fails, so basically never, but still worth fixing.