### PR TITLE
Update response parse failure return type for errors

### DIFF
--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.h
@@ -64,7 +64,8 @@
    b.) the downloaded data - which contains the JSON error message - gets removed again
    @param fileURL the location to which the data have been downloaded
    @param the error pointer returned from the server. If this is nil and the status code is NOT ok we will create and error here
+   @return YES if successful (error is nil) or NO otherwise
  */
-- (void)parseFailureResponseFromFileDownloadURL:(NSURL *)fileURL error:(NSError **)error;
+- (BOOL)parseFailureResponseFromFileDownloadURL:(NSURL *)fileURL error:(NSError **)error;
 
 @end

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.m
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.m
@@ -92,17 +92,17 @@
     return innerSuccess;
 }
 
-- (void)parseFailureResponseFromFileDownloadURL:(NSURL *)fileURL
+- (BOOL)parseFailureResponseFromFileDownloadURL:(NSURL *)fileURL
                                           error:(NSError **)error;
 {
     if ([[[self class] correctStates] containsIndex:self.statusCode])
     {
-        return;
+        return YES;
     }
     NSFileManager *manager = [NSFileManager defaultManager];
     if (![manager fileExistsAtPath:fileURL.path])
     {
-        return;
+        return YES;
     }
 
     NSData *errorData = [NSData dataWithContentsOfFile:fileURL.path];
@@ -111,7 +111,7 @@
 
     if (nil == errorData)
     {
-        return;
+        return YES;
     }
     NSError *jsonError = nil;
     id jsonObj = [NSJSONSerialization JSONObjectWithData:errorData
@@ -131,9 +131,10 @@
             *error = [NSError errorWithDomain:kMendeleyErrorDomain
                                          code:self.statusCode
                                      userInfo:userinfo];
+            return NO;
         }
     }
-
+    return YES;
 }
 
 


### PR DESCRIPTION
Last problem reported by Xcode “Analyse”:

> MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.m:95:1
> Method accepting NSError** should have a non-void return value to indicate whether or not an error occurred

That’s not really a bug in itself, but I think the compiler has a point here, and error parameters shouldn’t be used to test if something has failed, only to know the why/how. 

Also, changing the return type doesn’t break how this method is being used, so it’s all for the better.