### PR TITLE
Adds Carthage/Build in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ MendeleyKit/Pods/
 /Pods/
 
 *.xcscmblueprint
+Carthage/Build


### PR DESCRIPTION
Adds Carthage/Build in .gitignore to make mendeleykit behave better with Carthage 

(Carthage/Build is a folder output by the Carthage package manager – it can end up getting created inside mendeleykit even if mendeleykit itself has no dependencies expressed via Carthage).