### PR TITLE
Clean up readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to submit code
 
-This is an early-bird version of the MendeleyKit. We welcome your thoughts and suggestions. If you would like to make active contributions, e.g. code changes/additions,
+This is an early-bird version of MendeleyKit. We welcome your thoughts and suggestions. If you would like to make active contributions, e.g. code changes/additions:
 
-- code submissions should only be made to Development branch via pull requests. 
-- you may create your own subbranches from Development and submit to it at will. However, if you want to merge it into Development then you would need to create a pull request
-- Note: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!
+- code submissions should only be made to `Development` branch via pull requests.
+- you may create your own subbranches from `Development` and submit to it at will. However, if you want to merge it into `Development` then you would need to create a pull request.
+- **Note**: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!

--- a/README.md
+++ b/README.md
@@ -5,35 +5,35 @@ Released: May 2016 (2.1.3)
 
 ## About MendeleyKit 2.1.x ##
 MendeleyKit is a standalone library/framework providing convenience methods
-and classes for using the [Mendeley API](http://dev.mendeley.com) in Mac OSX or
-iOS applications.
+and classes for using the [Mendeley API](http://dev.mendeley.com) in iOS and
+OS X applications.
 
-Since its launch in Oct 2014 MendeleyKit has gone through a number of changes and improvements.
+Since its launch in October 2014, MendeleyKit has gone through a number of changes and improvements.
 Version 2 of the SDK is introducing a MendeleyKitiOS dynamic framework, including Swift 2.0 code.
-In addition to that some API additions were introduced (e.g. Mendeley features API enabling remote feature enabling).
+In addition to that, some API additions were introduced (e.g. Mendeley features API enabling remote feature enabling).
 
-Version 2 still supports MendeleyKit as a standalone static library for iOS and OSX. However, users of the SDK
+Version 2 still supports MendeleyKit as a standalone static library for iOS and OS X. However, users of the SDK
 should be advised that the use of static library is deprecated and may be discontinued at a future release.
 
 ## Minimum Requirements ##
 
-### Minimum Requirements - Static Library MendeleyKit ###
-XCode 6.x
+### As a Static Library (2.0.x) ###
+Xcode 6.x
 iOS 7.x or higher
 
-### Minimum Requirements - Framework ###
-XCode 7
+### As a Framework ###
+Xcode 7
 iOS 8 or higher
-OSX 10.9 or higher
+OS X 10.9 or higher
 
-## Installation/Cocoapod ##
-The easiest way to include MendeleyKit in your project is to use cocoapods. In order to support both
+## Installation (CocoaPods) ##
+The easiest way to include MendeleyKit in your project is to use CocoaPods. In order to support both
 dynamic frameworks and legacy static library of MendeleyKit, we introduced separate Podspec files
-- MendeleyKit.podspec: use this for static library of MendeleyKit (will not contain Swift code and some of the new APIs, such as analytics). Note this is deprecated and may be removed in future releases.
-- MendeleyKitiOS.podspec - the iOS dynamic Framework. Requires iOS8 min and XCode 7
-- MendeleyKitOSX.podspec - the OSX framework.
+- `MendeleyKit.podspec`: use this for static library of MendeleyKit (will not contain Swift code and some of the new APIs, such as analytics). Note this is deprecated and may be removed in future releases.
+- `MendeleyKitiOS.podspec`: the iOS dynamic framework. Requires iOS 8 min and Xcode 7
+- `MendeleyKitOSX.podspec`: the OS X framework.
 
-### Cocoapods for frameworks ###
+### CocoaPods for frameworks ###
 
 #### Your client Podfile using the iOS Framework ####
 Use this in your Podfile:
@@ -42,8 +42,7 @@ use_frameworks!
 pod 'MendeleyKitiOS', :git => 'https://github.com/Mendeley/mendeleykit.git'
 ```
 
-*Note*: the framework supports both WebKit and UIWebView for login process (the latter is deprecated). To ensure you use the WebKit version
-of the Kit you may want to include the following lines in your Podfile:
+*Note*: the framework supports both `WKWebView` and `UIWebView` for login process (the latter is deprecated). To ensure you use the WebKit version of the Kit, you may want to include the following lines in your Podfile:
 ```
 post_install do |installer|
   installer.pods_project.targets.each do |target|
@@ -54,23 +53,21 @@ post_install do |installer|
   end
 end
 ```
-(for cocoapods versions earlier than 0.38 use installer.project.targets.each instead of installer.pods_project.targets.each)
+(for CocoaPods versions earlier than 0.38, use `installer.project.targets.each` instead of `installer.pods_project.targets.each`)
 
-*Note*: 
-Using *use_frameworks!* means that all included dependencies will be interpreted as frameworks. At this stage there is no provision in cocoapods to selectively mark some pods as frameworks and others as static library.
+*Note*: Using `use_frameworks!` means that all included dependencies will be interpreted as frameworks. At this stage, there is no provision in CocoaPods to selectively mark some pods as frameworks and others as static libraries.
 
-Once done do a 
+Once done, do a:
 ```
 pod install
 ```
 
-**NOTE**: Cocoapods is generating an umbrella header in its PODs folder. This has been
-known to cause problems when compiling or doing a 'pod lint MendeleyKitiOS.podspec'.
-The error message is '...include of non-modular header in framework...'. Cocoapods has a whole message trail for this problem
-which first appeared with XCode 7.1. 
-The line below is a workaround, which basically comments out the #include "MendeleyKitiOS.h" line in the pod generated umbrella header. 
+**Note**: CocoaPods is generating an umbrella header in its Pods folder. This has been
+known to cause problems when compiling or doing a `pod lint MendeleyKitiOS.podspec`.
+The error message is '...include of non-modular header in framework...'. CocoaPods has a whole message trail for this problem which first appeared with Xcode 7.1.
+The line below is a workaround, which basically comments out the `#include "MendeleyKitiOS.h"` line in the pod generated umbrella header.
 This seems to fix the issue.
-The example below demonstrates how this can be used in a post install instruction in a Podfile 
+The example below demonstrates how this can be used in a post-install instruction in a Podfile:
 
 ```
 post_install do |installer|
@@ -86,98 +83,97 @@ end
 ```
 
 ### Your client Podfile for using the static library (deprecated) ###
-You can use the legacy static library of MendeleyKit using the MendeleyKit.podspec
-Note: the static library of MendeleyKit will not include any Swift classes - including
+You can use the legacy static library of MendeleyKit using `MendeleyKit.podspec`.
+
+**Note**: the static library of MendeleyKit will not include any Swift classes - including
 the new MendeleyAnalytics classes/methods.
 
-The Podfile in your project should include the following line
+The Podfile in your project should include the following line:
 
 ```
 pod 'MendeleyKit', :git => 'https://github.com/Mendeley/mendeleykit.git'
 ```
 
-From command line, simply do 
+From the command line, simply do:
 ```
 pod install
 ```
 
-For further information on Cocoapods see [Cocoapods](http://cocoapods.org/).
+For further information on CocoaPods, see [CocoaPods.org](http://cocoapods.org/).
 
 Alternatively, you may clone the public MendeleyKit from our github repository.
 
 ## Upgrading from Previous versions of MendeleyKit ##
 
-### Upgrading the headers/import in Objective C code for Framework ###
+### Upgrading the headers/import in Objective-C code for Framework ###
 Using the MendeleyKitiOS framework means you will need to change your headers.
-All public headers in the MendeleyKit are included in the framework umbrella header MendeleyKitiOS.h.
+All public headers in MendeleyKit are included in the framework umbrella header `MendeleyKitiOS.h`.
 Please, replace all explicit MendeleyKit imports in your code with this one header.
 
 ```
 #import <MendeleyKitiOS/MendeleyKitiOS.h>
 ```
-You may want to use the more modern syntax
+You may want to use the more modern syntax:
 ```
 @import MendeleyKitiOS;
 ```
 ### Upgrading the headers/import for use of static library ###
-*Note*: If you are using the static library version of MendeleyKit you will need to use the following syntax
-(as the workspace has now modules enabled in the build sittings)
+*Note*: if you are using the static library version of MendeleyKit, you will need to use the following syntax
+(as the workspace has now modules enabled in the build sittings):
 
 ```
 #import <MendeleyKit/MendeleyKit.h>
 ```
 
 ### Client build settings ###
-- client should have 'Enable modules' set to Yes
-- MendeleyKit currently has bitcode disabled in its settings for backward compatibility reasons. You may need to do the same in the client using the MendeleyKit framework/lib.
+- client should have `Enable modules` set to `Yes`
+- MendeleyKit currently has bitcode generation disabled in its settings for backward compatibility reasons. You may need to do the same in the client using the MendeleyKit framework/library.
 
 
 ## Getting Started ##
-MendeleyKit XCode workspace includes a MendeleyKitExample project. This demonstrates
+The MendeleyKit Xcode workspace includes a MendeleyKitExample project. This demonstrates
 basic functionality such as authenticating with the Mendeley server, 
 obtaining a list of documents, files and groups.
 
 It is recommended to consult with the classes contained in the MendeleyKitExample project.
 
-In addition the github repository includes a MendeleyKitHelp.zip file. This contains
-a complete reference set in HTML and Docset format.
+In addition, the GitHub repository includes a `MendeleyKitHelp.zip` file. This contains
+a complete reference set in HTML and Docset formats.
 
-When running the MendeleyKitExample app, please ensure you have
+When running the MendeleyKitExample app, please ensure you have:
 - client ID
 - client secret key
 - redirect URI 
 
-They need to be entered in the ViewController.h file.
+They need to be entered in the `ViewController.h` file.
 Note: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!
 
-[Mendeley API](http://dev.mendeley.com) has links to create your app client id, key and redirect URIs.
+[Mendeley API](http://dev.mendeley.com) has links to create your app client ID, key and redirect URIs.
 
 ## Registering a Client with the Mendeley Dev Portal ##
 Every client communicating with the server needs to be registered with the Mendeley developer portal [Mendeley API](http://dev.mendeley.com).
 
-Registration is quick, painless and free. It will give you the 3 essential ingredients you will need to supply when using the MendeleyKit in your app
+Registration is quick, painless and free. It will give you the 3 essential ingredients you will need to supply when using MendeleyKit in your app:
 - client ID
 - client secret key
 - redirect URI
 
 These values need to match *exactly* the ones from the dev portal.
-The redirect URI should be a fully formed URL, such as - e.g. http://localhost/myredirect (rather than just 'localhost/myredirect). This avoids any pitfalls or 'Frame load interrupted' messages in the UIWebView kit.
+The redirect URI should be a fully formed URL, such as `http://localhost/myredirect` (rather than just `localhost/myredirect`). This avoids any pitfalls or 'Frame load interrupted' messages in UIWebView.
 
 
-## How to submit code ##
-This is an early-bird version of the MendeleyKit. We welcome your thoughts and suggestions. If you would like to make active contributions, e.g. code changes/additions,
+## How to Submit Code ##
+This is an early-bird version of MendeleyKit. We welcome your thoughts and suggestions. If you would like to make active contributions, e.g. code changes/additions:
 
-- code submissions should only be made to Development branch via pull requests. 
-- you may create your own subbranches from Development and submit to it at will. However, if you want to merge it into Development then you would need to create a pull request
-- Note: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!
+- code submissions should only be made to `Development` branch via pull requests.
+- you may create your own subbranches from `Development` and submit to it at will. However, if you want to merge it into `Development` then you would need to create a pull request.
+- **Note**: code containing client IDs, client secrets, redirect URI will not be accepted in pull requests!
 
 
 ## Software Releases ##
-All official releases of the MendeleyKit are tagged versions on master. Mendeley reserves the rights to merge changes made to Development into master.
-Each release will contain a RELEASE text file outlining changes made.
+All official releases of MendeleyKit are tagged versions on `master`. Mendeley reserves the rights to merge changes made to `Development` into `master`.
+Each release will contain a `RELEASE` text file outlining changes made.
 
 ## Reporting Issues ##
-Please use the Issues feature on github to report any problems you encounter with the MendeleyKit. 
-For feedback/suggestions please contact: api@mendeley.com
-
-
+Please use the Issues feature on GitHub to report any problems you encounter with MendeleyKit.
+For feedback/suggestions, please contact: api@mendeley.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MendeleyKit the Mendeley SDK for Objective C #
+# MendeleyKit — the Mendeley SDK for Objective-C #
 
 Released: May 2016 (2.1.3)
 


### PR DESCRIPTION
(Sorry to be _that_ guy.)

This pull requests improves the formatting, addresses some inconsistencies, and fixes a couple of typos in the 'readme' and 'contributing' Markdown files.

I also switched from instances of "the MendeleyKit" to just "MendeleyKit", to follow the style generally used for UIKit and other Apple '~Kit' frameworks.