### PR TITLE
Refactor token refresh code

### DIFF
--- a/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
@@ -1653,12 +1653,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C46656601B3842B0005F762A /* Build configuration list for PBXNativeTarget "MendeleyKitiOSTests" */;
 			buildPhases = (
-				FEE64BBFF23189E9C8F16241 /* Check Pods Manifest.lock */,
+				FEE64BBFF23189E9C8F16241 /* [CP] Check Pods Manifest.lock */,
 				C46656511B3842B0005F762A /* Sources */,
 				C46656521B3842B0005F762A /* Frameworks */,
 				C46656531B3842B0005F762A /* Resources */,
-				120B78C20A86AED3C30CDD32 /* Copy Pods Resources */,
-				09939FE7E1FAD2813F6C0730 /* Embed Pods Frameworks */,
+				120B78C20A86AED3C30CDD32 /* [CP] Copy Pods Resources */,
+				09939FE7E1FAD2813F6C0730 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1691,12 +1691,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C4CD516119DAD9E400C8EB8D /* Build configuration list for PBXNativeTarget "MendeleyKitTests" */;
 			buildPhases = (
-				ACAF36624CF849239ECD9BBD /* Check Pods Manifest.lock */,
+				ACAF36624CF849239ECD9BBD /* [CP] Check Pods Manifest.lock */,
 				C4CD514719DAD9E400C8EB8D /* Sources */,
 				C4CD514819DAD9E400C8EB8D /* Frameworks */,
 				C4CD514919DAD9E400C8EB8D /* Resources */,
-				815E227FAF9B438D8C025191 /* Copy Pods Resources */,
-				AC8836685D97A921CDC3CF3C /* Embed Pods Frameworks */,
+				815E227FAF9B438D8C025191 /* [CP] Copy Pods Resources */,
+				AC8836685D97A921CDC3CF3C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1819,14 +1819,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09939FE7E1FAD2813F6C0730 /* Embed Pods Frameworks */ = {
+		09939FE7E1FAD2813F6C0730 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1834,14 +1834,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		120B78C20A86AED3C30CDD32 /* Copy Pods Resources */ = {
+		120B78C20A86AED3C30CDD32 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1849,14 +1849,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		815E227FAF9B438D8C025191 /* Copy Pods Resources */ = {
+		815E227FAF9B438D8C025191 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1864,14 +1864,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AC8836685D97A921CDC3CF3C /* Embed Pods Frameworks */ = {
+		AC8836685D97A921CDC3CF3C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1879,14 +1879,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ACAF36624CF849239ECD9BBD /* Check Pods Manifest.lock */ = {
+		ACAF36624CF849239ECD9BBD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1894,14 +1894,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		FEE64BBFF23189E9C8F16241 /* Check Pods Manifest.lock */ = {
+		FEE64BBFF23189E9C8F16241 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.m
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.m
@@ -295,6 +295,74 @@
 }
 
 
+#pragma mark - Authentication helper
+
+- (void)checkAuthenticationThenRefreshTokenThenPerform:(void(^)())operationBlock completionBlock:(MendeleyCompletionBlock)completionBlock
+{
+    if (self.isAuthenticated)
+    {
+        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
+            if (success)
+            {
+                operationBlock();
+            }
+            else
+            {
+                completionBlock(NO, error);
+            }
+        }];
+    }
+    else
+    {
+        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
+        completionBlock(NO, unauthorisedError);
+    }
+}
+
+- (void)checkAuthenticationThenRefreshTokenThenPerform:(void(^)())operationBlock objectCompletionBlock:(MendeleyObjectCompletionBlock)completionBlock
+{
+    if (self.isAuthenticated)
+    {
+        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
+            if (success)
+            {
+                operationBlock();
+            }
+            else
+            {
+                completionBlock(nil, nil, error);
+            }
+        }];
+    }
+    else
+    {
+        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
+        completionBlock(nil, nil, unauthorisedError);
+    }
+}
+
+- (void)checkAuthenticationThenRefreshTokenThenPerform:(void(^)())operationBlock arrayCompletionBlock:(MendeleyArrayCompletionBlock)completionBlock
+{
+    if (self.isAuthenticated)
+    {
+        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
+            if (success)
+            {
+                operationBlock();
+            }
+            else
+            {
+                completionBlock(nil, nil, error);
+            }
+        }];
+    }
+    else
+    {
+        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
+        completionBlock(nil, nil, unauthorisedError);
+    }
+}
+
 
 #pragma mark - Profiles
 
@@ -302,25 +370,10 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.profilesAPI pullMyProfileWithTask:task
-                                         completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.profilesAPI pullMyProfileWithTask:task
+                                completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -330,26 +383,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.profilesAPI pullProfile:profileID
-                                          task:task
-                               completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.profilesAPI pullProfile:profileID
+                                 task:task
+                      completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -399,26 +437,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.profilesAPI updateMyProfile:myProfile
-                                              task:task
-                                   completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.profilesAPI updateMyProfile:myProfile
+                                     task:task
+                          completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 
@@ -432,26 +455,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI documentListWithLinkedURL:linkURL
-                                                         task:task
-                                              completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI documentListWithLinkedURL:linkURL
+                                                task:task
+                                     completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -461,26 +469,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI documentListWithQueryParameters:queryParameters
-                                                               task:task
-                                                    completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI documentListWithQueryParameters:queryParameters
+                                                      task:task
+                                           completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -491,27 +484,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI authoredDocumentListForUserWithProfileID:profileID
-                                                             queryParameters:queryParameters
-                                                                        task:task
-                                                             completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI authoredDocumentListForUserWithProfileID:profileID
+                                                    queryParameters:queryParameters
+                                                               task:task
+                                                    completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -521,26 +499,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI documentWithDocumentID:documentID
-                                                      task:task
-                                           completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI documentWithDocumentID:documentID
+                                             task:task
+                                  completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -551,26 +514,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI catalogDocumentWithCatalogID:catalogID
-                                                            task:task
-                                                 completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI catalogDocumentWithCatalogID:catalogID
+                                                   task:task
+                                        completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -580,26 +528,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI catalogDocumentWithParameters:queryParameters
-                                                             task:task
-                                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI catalogDocumentWithParameters:queryParameters
+                                                    task:task
+                                         completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 
@@ -610,26 +543,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI createDocument:mendeleyDocument
-                                              task:task
-                                   completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI createDocument:mendeleyDocument
+                                     task:task
+                          completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -639,26 +557,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI updateDocument:updatedDocument
-                                              task:task
-                                   completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI updateDocument:updatedDocument
+                                     task:task
+                          completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -669,26 +572,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI deleteDocumentWithID:documentID
-                                                    task:task
-                                         completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI deleteDocumentWithID:documentID
+                                           task:task
+                                completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -698,26 +586,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI trashDocumentWithID:documentID
-                                                   task:task
-                                        completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI trashDocumentWithID:documentID
+                                          task:task
+                               completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -736,27 +609,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI deletedDocumentsSince:deletedSince
-                                                  groupID:groupID
-                                                     task:task
-                                          completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI deletedDocumentsSince:deletedSince
+                                         groupID:groupID
+                                            task:task
+                                 completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -766,26 +624,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI trashedDocumentListWithLinkedURL:linkURL
-                                                                task:task
-                                                     completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI trashedDocumentListWithLinkedURL:linkURL
+                                                       task:task
+                                            completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -795,26 +638,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI trashedDocumentListWithQueryParameters:queryParameters
-                                                                      task:task
-                                                           completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI trashedDocumentListWithQueryParameters:queryParameters
+                                                             task:task
+                                                  completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -824,26 +652,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI deleteTrashedDocumentWithID:documentID
-                                                           task:task
-                                                completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI deleteTrashedDocumentWithID:documentID
+                                                  task:task
+                                       completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -853,26 +666,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI restoreTrashedDocumentWithID:documentID
-                                                            task:task
-                                                 completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI restoreTrashedDocumentWithID:documentID
+                                                   task:task
+                                        completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -882,26 +680,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI trashedDocumentWithDocumentID:documentID
-                                                             task:task
-                                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI trashedDocumentWithDocumentID:documentID
+                                                    task:task
+                                         completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -912,27 +695,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI documentFromFileWithURL:fileURL
-                                                   mimeType:mimeType
-                                                       task:task
-                                            completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI documentFromFileWithURL:fileURL
+                                          mimeType:mimeType
+                                              task:task
+                                   completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -945,26 +713,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.metedataAPI metadataLookupWithQueryParameters:queryParameters
-                                                                task:task
-                                                     completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.metedataAPI metadataLookupWithQueryParameters:queryParameters
+                                                       task:task
+                                            completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -975,25 +728,10 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI documentTypesWithTask:task
-                                          completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI documentTypesWithTask:task
+                                 completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1004,25 +742,10 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.documentsAPI identifierTypesWithTask:task
-                                            completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.documentsAPI identifierTypesWithTask:task
+                                   completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1034,26 +757,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI fileListWithQueryParameters:queryParameters
-                                                       task:task
-                                            completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI fileListWithQueryParameters:queryParameters
+                                              task:task
+                                   completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1065,27 +773,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI fileWithFileID:fileID saveToURL:fileURL
-                                          task:task
-                                 progressBlock:progressBlock
-                               completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI fileWithFileID:fileID saveToURL:fileURL
+                                 task:task
+                        progressBlock:progressBlock
+                      completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1114,30 +807,15 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI createFile:fileURL
-                                   filename:filename
-                                contentType:contentType
-                  relativeToDocumentURLPath:documentURLPath
-                                       task:task
-                              progressBlock:progressBlock
-                            completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI createFile:fileURL
+                         filename:filename
+                      contentType:contentType
+        relativeToDocumentURLPath:documentURLPath
+                             task:task
+                    progressBlock:progressBlock
+                  completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1148,26 +826,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI deleteFileWithID:fileID
-                                            task:task
-                                 completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI deleteFileWithID:fileID
+                                   task:task
+                        completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1177,26 +840,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI fileListWithLinkedURL:linkURL
-                                                 task:task
-                                      completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI fileListWithLinkedURL:linkURL
+                                        task:task
+                             completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1215,27 +863,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI deletedFilesSince:deletedSince
-                                          groupID:groupID
-                                             task:task
-                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI deletedFilesSince:deletedSince
+                                 groupID:groupID
+                                    task:task
+                         completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1245,26 +878,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI recentlyReadWithParameters:queryParameters
-                                                      task:task
-                                           completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI recentlyReadWithParameters:queryParameters
+                                             task:task
+                                  completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1274,26 +892,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI addRecentlyRead:recentlyRead
-                                           task:task
-                                completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI addRecentlyRead:recentlyRead
+                                  task:task
+                       completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 
@@ -1306,26 +909,11 @@
    {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.filesAPI updateRecentlyRead:recentlyRead
-                                              task:task
-                                   completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.filesAPI updateRecentlyRead:recentlyRead
+                                     task:task
+                          completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
    }
@@ -1339,27 +927,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI documentListFromFolderWithID:folderID
-                                                    parameters:queryParameters
-                                                          task:task
-                                               completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI documentListFromFolderWithID:folderID
+                                           parameters:queryParameters
+                                                 task:task
+                                      completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1370,27 +943,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI addDocument:mendeleyDocumentId
-                                     folderID:folderID
-                                         task:task
-                              completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI addDocument:mendeleyDocumentId
+                            folderID:folderID
+                                task:task
+                     completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1400,26 +958,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI createFolder:mendeleyFolder
-                                          task:task
-                               completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI createFolder:mendeleyFolder
+                                 task:task
+                      completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1429,26 +972,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI folderListWithLinkedURL:linkURL
-                                                     task:task
-                                          completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI folderListWithLinkedURL:linkURL
+                                            task:task
+                                 completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1458,26 +986,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI documentListInFolderWithLinkedURL:linkURL
-                                                               task:task
-                                                    completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI documentListInFolderWithLinkedURL:linkURL
+                                                      task:task
+                                           completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1487,26 +1000,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI folderListWithQueryParameters:queryParameters
-                                                           task:task
-                                                completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI folderListWithQueryParameters:queryParameters
+                                                  task:task
+                                       completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1516,26 +1014,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI folderWithFolderID:folderID
-                                                task:task
-                                     completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI folderWithFolderID:folderID
+                                       task:task
+                            completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1545,26 +1028,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI deleteFolderWithID:folderID
-                                                task:task
-                                     completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI deleteFolderWithID:folderID
+                                       task:task
+                            completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1574,26 +1042,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI updateFolder:updatedFolder
-                                          task:task
-                               completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI updateFolder:updatedFolder
+                                 task:task
+                      completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1602,27 +1055,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.foldersAPI deleteDocumentWithID:documentID
-                                      fromFolderWithID:folderID
-                                                  task:task
-                                       completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.foldersAPI deleteDocumentWithID:documentID
+                             fromFolderWithID:folderID
+                                         task:task
+                              completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1634,27 +1072,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupListWithQueryParameters:queryParameters
-                                                     iconType:iconType
-                                                         task:task
-                                              completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupListWithQueryParameters:queryParameters
+                                            iconType:iconType
+                                                task:task
+                                     completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 
@@ -1666,27 +1089,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupListWithLinkedURL:linkURL
-                                               iconType:iconType
-                                                   task:task
-                                        completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupListWithLinkedURL:linkURL
+                                      iconType:iconType
+                                          task:task
+                               completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 
@@ -1698,27 +1106,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupWithGroupID:groupID
-                                         iconType:iconType
-                                             task:task
-                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupWithGroupID:groupID
+                                iconType:iconType
+                                    task:task
+                         completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 
@@ -1729,26 +1122,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupListWithQueryParameters:queryParameters
-                                                         task:task
-                                              completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupListWithQueryParameters:queryParameters
+                                                task:task
+                                     completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1758,26 +1136,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupListWithLinkedURL:linkURL
-                                                   task:task
-                                        completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupListWithLinkedURL:linkURL
+                                          task:task
+                               completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1787,26 +1150,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.groupsAPI groupWithGroupID:groupID
-                                             task:task
-                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.groupsAPI groupWithGroupID:groupID
+                                    task:task
+                         completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1850,25 +1198,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI annotationWithAnnotationID:annotationID task:task
-                                                 completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI annotationWithAnnotationID:annotationID
+                                                   task:task
+                                        completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1878,25 +1212,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI deleteAnnotationWithID:annotationID task:task
-                                             completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(NO, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI deleteAnnotationWithID:annotationID
+                                               task:task
+                                    completionBlock:completionBlock];
+    } completionBlock:completionBlock];
 
     return task;
 }
@@ -1906,25 +1226,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI updateAnnotation:updatedMendeleyAnnotation task:task
-                                       completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI updateAnnotation:updatedMendeleyAnnotation
+                                         task:task
+                              completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1934,25 +1240,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI createAnnotation:mendeleyAnnotation task:task
-                                       completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI createAnnotation:mendeleyAnnotation
+                                         task:task
+                              completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
 
     return task;
 }
@@ -1962,25 +1254,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI annotationListWithLinkedURL:linkURL task:task
-                                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI annotationListWithLinkedURL:linkURL
+                                                    task:task
+                                         completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 
@@ -1992,25 +1270,11 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI annotationListWithQueryParameters:queryParameters task:task
-                                                        completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI annotationListWithQueryParameters:queryParameters
+                                                          task:task
+                                               completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2029,27 +1293,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.annotationsAPI deletedAnnotationsSince:deletedSince
-                                                      groupID:groupID
-                                                         task:task
-                                              completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.annotationsAPI deletedAnnotationsSince:deletedSince
+                                             groupID:groupID
+                                                task:task
+                                     completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2062,27 +1311,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.followersAPI followersForUserWithID:profileID
-                                                parameters:parameters
-                                                      task:task
-                                           completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI followersForUserWithID:profileID
+                                       parameters:parameters
+                                             task:task
+                                  completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2093,27 +1327,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.followersAPI followedByUserWithID:profileID
-                                              parameters:parameters
-                                                    task:task
-                                         completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI followedByUserWithID:profileID
+                                     parameters:parameters
+                                           task:task
+                                completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2124,27 +1343,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.followersAPI pendingFollowersForUserWithID:profileID
-                                                       parameters:parameters
-                                                             task:task
-                                                  completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI pendingFollowersForUserWithID:profileID
+                                              parameters:parameters
+                                                    task:task
+                                         completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2155,27 +1359,12 @@
 {
     MendeleyTask *task = [MendeleyTask new];
 
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
-             if (success)
-             {
-                 [self.followersAPI pendingFollowedByUserWithID:profileID
-                                                     parameters:parameters
-                                                           task:task
-                                                completionBlock:completionBlock];
-             }
-             else
-             {
-                 completionBlock(nil, nil, error);
-             }
-         }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI pendingFollowedByUserWithID:profileID
+                                            parameters:parameters
+                                                  task:task
+                                       completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
 
     return task;
 }
@@ -2184,26 +1373,13 @@
          completionBlock:(MendeleyObjectCompletionBlock)completionBlock
 {
     MendeleyTask *task = [MendeleyTask new];
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-            if (success)
-            {
-                [self.followersAPI followUserWithID:followedID
-                                               task:task
-                                    completionBlock:completionBlock];
-            }
-            else
-            {
-                completionBlock(nil, nil, error);
-            }
-        }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI followUserWithID:followedID
+                                       task:task
+                            completionBlock:completionBlock];
+    } objectCompletionBlock:completionBlock];
+
     return task;
 }
 
@@ -2211,26 +1387,13 @@
                   completionBlock:(MendeleyCompletionBlock)completionBlock
 {
     MendeleyTask *task = [MendeleyTask new];
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-            if (success)
-            {
-                [self.followersAPI acceptFollowRequestWithID:requestID
-                                                        task:task
-                                             completionBlock:completionBlock];
-            }
-            else
-            {
-                completionBlock(NO, error);
-            }
-        }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI acceptFollowRequestWithID:requestID
+                                                task:task
+                                     completionBlock:completionBlock];
+    } completionBlock:completionBlock];
+
     return task;
 }
 
@@ -2238,26 +1401,13 @@
                completionBlock:(MendeleyCompletionBlock)completionBlock
 {
     MendeleyTask *task = [MendeleyTask new];
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-            if (success)
-            {
-                [self.followersAPI stopOrDenyRelationshipWithID:relationshipID
-                                                     task:task
-                                          completionBlock:completionBlock];
-            }
-            else
-            {
-                completionBlock(NO, error);
-            }
-        }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(NO, unauthorisedError);
-    }
+
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.followersAPI stopOrDenyRelationshipWithID:relationshipID
+                                                   task:task
+                                        completionBlock:completionBlock];
+    } completionBlock:completionBlock];
+
     return task;
 }
 
@@ -2265,27 +1415,13 @@
 - (MendeleyTask *)applicationFeaturesWithCompletionBlock:(MendeleyArrayCompletionBlock)completionBlock
 {
     MendeleyTask *task = [MendeleyTask new];
-    if (self.isAuthenticated)
-    {
-        [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock:^(BOOL success, NSError *error) {
-            if (success)
-            {
-                [self.featuresAPI applicationFeaturesWithTask:task
-                                              completionBlock:completionBlock];
-            }
-            else
-            {
-                completionBlock(nil, nil, error);
-            }
-        }];
-    }
-    else
-    {
-        NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
-        completionBlock(nil, nil, unauthorisedError);
-    }
+
+    [self checkAuthenticationThenRefreshTokenThenPerform:^{
+        [self.featuresAPI applicationFeaturesWithTask:task
+                                      completionBlock:completionBlock];
+    } arrayCompletionBlock:completionBlock];
+
     return task;
-    
 }
 
 

--- a/MendeleyKit/Podfile
+++ b/MendeleyKit/Podfile
@@ -1,11 +1,11 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-target :MendeleyKitTests, :exclusive => true  do
+target :MendeleyKitTests  do
     pod 'OCMock'
 end
 
-target :MendeleyKitiOSTests, :exclusive => true do
+target :MendeleyKitiOSTests do
     pod 'OCMock'
 end
 


### PR DESCRIPTION
This pull request refactors a piece of code that is used for most operations, by moving this code to a dedicated method, limiting code duplication. This pull request does **not** change how MendeleyKit works, it just moves a piece of code that was copied-pasted many times to a common method.

The code in question checks the user authentication status, refreshes the OAuth token if necessary, and generates an error if something goes wrong. If everything goes well, the main operation is then performed.

### Before

``` objc
if (self.isAuthenticated)
{
  [MendeleyOAuthTokenHelper refreshTokenWithRefreshBlock: ^(BOOL success, NSError *error) {
    if (success)
    {
      // Perform operation...
    }
    else
    {
      completionBlock(nil, nil, error);
    }
  }];
}
else
{
  NSError *unauthorisedError = [NSError errorWithCode:kMendeleyUnauthorizedErrorCode];
  completionBlock(nil, nil, unauthorisedError);
}
```

### After

``` objc
[self checkAuthenticationThenRefreshTokenThenPerform:^{
  // Perform operation...
} objectCompletionBlock:completionBlock];
```

### New methods

This piece of code is moved to 3 new methods:

- `checkAuthenticationThenRefreshTokenThenPerform:completionBlock:`
- `checkAuthenticationThenRefreshTokenThenPerform:objectCompletionBlock:`
- `checkAuthenticationThenRefreshTokenThenPerform:arrayCompletionBlock:`

The only difference is the type of completion block, that varies depending on the operation being performed.

--

This pull request also updates the main workspace Podfile to make it compatible with CocoaPods 1.0 (`:exclusive` option no longer available), in order to `pod install` the workspace. 