### PR TITLE
Configure Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: objective-c
+osx_image: xcode7.3
+
+script:
+  - cd MendeleyKit
+  - pod install
+  - xcodebuild -workspace MendeleyKit.xcworkspace -scheme MendeleyKitiOS -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test


### PR DESCRIPTION
This pull request adds a Travis CI configuration file, to explicitly define the build & test script.

Having this integration is useful to review commits and pull requests directly from GitHub.

You can see an example of successful integration build on the fork itself: https://travis-ci.org/vtourraine/mendeleykit/builds/143007356