### PR TITLE
Fix warnings in test code

### DIFF
--- a/MendeleyKit/MendeleyKitTests/ColorExtensionTests.swift
+++ b/MendeleyKit/MendeleyKitTests/ColorExtensionTests.swift
@@ -36,7 +36,7 @@ class ColorExtensionTests: XCTestCase {
             
             if (hexString == calculatedHexString)
             {
-                counter++
+                counter += 1
             }
         }
         
@@ -59,7 +59,7 @@ class ColorExtensionTests: XCTestCase {
             
             if (hexString == calculatedHexString)
             {
-                counter++
+                counter += 1
             }
         }
         
@@ -72,13 +72,13 @@ class ColorExtensionTests: XCTestCase {
         
         for i in 0...255
         {
-            let rgb:UInt32 = (UInt32)((Int)(i)<<16)
+            // let rgb:UInt32 = (UInt32)((Int)(i)<<16)
                         
             let color = UIColor(redInt: (UInt32)(i), greenInt: 0, blueInt: 0)
             
             if (color.redComponentInt() == (UInt32)(i))
             {
-                counter++
+                counter += 1
             }
         }
         

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
@@ -55,7 +55,7 @@ class MendeleyAnalyticsTests: XCTestCase {
     func testAddEvents()
     {
         var array = [MendeleyAnalyticsEvent]()
-        for var count = 0; count < 20; count++
+        for count in 0 ..< 20
         {
             let event = MendeleyAnalyticsEvent()
             event.name = "TestPDFEvent\(count)"
@@ -67,14 +67,12 @@ class MendeleyAnalyticsTests: XCTestCase {
         
         let cachedEvents = manager.eventsFromArchive()
         XCTAssertTrue(20 == cachedEvents.count,"expected 20 events but got \(cachedEvents.count)")
-        var index = 0
-        for event in cachedEvents
+        for (index, event) in cachedEvents.enumerate()
         {
             let name = "TestPDFEvent\(index)"
             let profile = "ProfileID_\(index)"
             XCTAssertTrue(name == event.name,"expected name \(name) but got \(event.name)")
             XCTAssertTrue(profile == event.profile_uuid,"expected name \(profile) but got \(event.profile_uuid)")
-            index++
         }
 
     }
@@ -106,7 +104,7 @@ class MendeleyAnalyticsTests: XCTestCase {
         let profileID = NSUUID().UUIDString
         analytics.configureMendeleyAnalytics(profileID, clientVersionString: "2.6.0", clientIdentityString: "7")
         var array = [MendeleyAnalyticsEvent]()
-        for var count = 0; count < 20; count++
+        for count in 0 ..< 20
         {
             let event = MendeleyAnalyticsEvent()
             event.name = "TestPDFEvent\(count)"

--- a/MendeleyKit/MendeleyKitTests/MendeleyErrorManagerTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyErrorManagerTests.m
@@ -67,7 +67,7 @@
 
     XCTAssertNotNil(error, @"error should not be nil");
     XCTAssertEqualObjects(error.domain, kMendeleyErrorDomain, @"error domain should be %@, but is %@", kMendeleyErrorDomain, error.domain);
-    XCTAssertEqual(error.code, kMendeleyJSONTypeNotMappedToModelErrorCode, @"error code should be %d, but is %ld", kMendeleyJSONTypeNotMappedToModelErrorCode, (long) error.code);
+    XCTAssertEqual(error.code, kMendeleyJSONTypeNotMappedToModelErrorCode, @"error code should be %@, but is %ld", @(kMendeleyJSONTypeNotMappedToModelErrorCode), (long) error.code);
 }
 
 - (void)testCreateFakeError

--- a/MendeleyKit/MendeleyKitTests/MendeleyMockNetworkProvider.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyMockNetworkProvider.m
@@ -107,11 +107,21 @@
     [self executeMockTaskWithCompletionBlock:completionBlock];
 }
 
-
 - (void)         invokePUT:(NSURL *)baseURL
                        api:(NSString *)api
          additionalHeaders:(NSDictionary *)additionalHeaders
             bodyParameters:(NSDictionary *)bodyParameters
+    authenticationRequired:(BOOL)authenticationRequired
+                      task:(MendeleyTask *)task
+           completionBlock:(MendeleyResponseCompletionBlock)completionBlock
+{
+    [self executeMockTaskWithCompletionBlock:completionBlock];
+}
+
+- (void)         invokePUT:(NSURL *)baseURL
+                       api:(NSString *)api
+         additionalHeaders:(NSDictionary *)additionalHeaders
+                  jsonData:(NSData *)jsonData
     authenticationRequired:(BOOL)authenticationRequired
                       task:(MendeleyTask *)task
            completionBlock:(MendeleyResponseCompletionBlock)completionBlock

--- a/MendeleyKit/MendeleyKitTests/MendeleyResponseTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyResponseTests.m
@@ -76,7 +76,8 @@
 
 - (void)testParseURLResponse
 {
-    NSURLResponse *mockResponse = [[NSHTTPURLResponse alloc] initWithURL:nil statusCode:404 HTTPVersion:@"5.0" headerFields:nil];
+    NSURL *url = [NSURL URLWithString:@"http://example.com"];
+    NSURLResponse *mockResponse = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:404 HTTPVersion:@"5.0" headerFields:nil];
 
     MendeleyResponse *response = [[MendeleyResponse alloc] init];
 
@@ -91,7 +92,7 @@
     }
     for (NSInteger iStatus = 200; iStatus < 300; iStatus++)
     {
-        mockResponse = [[NSHTTPURLResponse alloc] initWithURL:nil statusCode:iStatus HTTPVersion:@"5.0" headerFields:nil];
+        mockResponse = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:iStatus HTTPVersion:@"5.0" headerFields:nil];
         [response parseURLResponse:mockResponse];
         XCTAssertTrue(response.success, @"The response should be successful for status code 200 to 299");
     }


### PR DESCRIPTION
This pull request fixes a handful of compilation warnings in the code for test target.

- Swift 2.2 deprecation
- missing mock method implementation
- nullability
- value type formatting

<img width="284" alt="screen shot 2016-07-07 at 15 35 30" src="https://cloud.githubusercontent.com/assets/886053/16679520/80422ff8-44e8-11e6-9b79-330d7a267e38.png"> <img width="289" alt="screen shot 2016-07-07 at 15 47 38" src="https://cloud.githubusercontent.com/assets/886053/16679533/9b17bd0c-44e8-11e6-9a84-3a6904b10ccd.png">
