### PR TITLE
Add generics annotations

### DIFF
--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.h
@@ -26,6 +26,8 @@
 #import <AppKit/AppKit.h>
 #endif
 
+@class MendeleyHighlightBox;
+
 
 @interface MendeleyAnnotation : MendeleyObject
 @property (nonatomic, strong) NSDate *created;
@@ -39,7 +41,7 @@
 @property (nonatomic, strong) NSString *document_id;
 @property (nonatomic, strong) NSString *filehash;
 @property (nonatomic, strong) NSDate *last_modified;
-@property (nonatomic, strong) NSArray *positions;
+@property (nonatomic, strong) NSArray <MendeleyHighlightBox *> *positions;
 @property (nonatomic, strong) NSString *privacy_level;
 @property (nonatomic, strong) NSString *profile_id;
 @property (nonatomic, strong) NSString *text;

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyCatalogDocument.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyCatalogDocument.h
@@ -26,9 +26,9 @@
 @interface MendeleyCatalogDocument : MendeleyObject
 @property (nonatomic, strong) NSString *link;
 @property (nonatomic, strong) NSNumber *reader_count;
-@property (nonatomic, strong) NSDictionary *reader_count_by_academic_status;
-@property (nonatomic, strong) NSDictionary *reader_count_by_subdiscipline;
-@property (nonatomic, strong) NSDictionary *reader_count_by_country;
+@property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *reader_count_by_academic_status;
+@property (nonatomic, strong) NSDictionary <NSString *, NSDictionary <NSString *, NSNumber *> *> *reader_count_by_subdiscipline;
+@property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *reader_count_by_country;
 /**
    NSNumber types (integer)
  */
@@ -52,7 +52,7 @@
 /**
    NSDictionary type (Identifiers, e.g. arxiv)
  */
-@property (nonatomic, strong) NSDictionary *identifiers;
+@property (nonatomic, strong) NSDictionary <NSString *, NSString *> *identifiers;
 
 /**
    NSDate types (stringDate)

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyCatalogDocument.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyCatalogDocument.h
@@ -20,6 +20,9 @@
 
 #import "MendeleyObject.h"
 
+@class MendeleyPerson;
+
+
 @interface MendeleyCatalogDocument : MendeleyObject
 @property (nonatomic, strong) NSString *link;
 @property (nonatomic, strong) NSNumber *reader_count;
@@ -41,10 +44,10 @@
 /**
    NSArray types (Person)
  */
-@property (nonatomic, strong) NSArray *authors;
-@property (nonatomic, strong) NSArray *editors;
-@property (nonatomic, strong) NSArray *websites;
-@property (nonatomic, strong) NSArray *keywords;
+@property (nonatomic, strong) NSArray <MendeleyPerson *> *authors;
+@property (nonatomic, strong) NSArray <MendeleyPerson *> *editors;
+@property (nonatomic, strong) NSArray <NSString *> *websites;
+@property (nonatomic, strong) NSArray <NSString *> *keywords;
 
 /**
    NSDictionary type (Identifiers, e.g. arxiv)

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyDocument.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyDocument.h
@@ -22,6 +22,9 @@
 #import "MendeleyObject.h"
 #import "MendeleyDocumentType.h"
 
+@class MendeleyPerson;
+
+
 @interface MendeleyDocument : MendeleyObject
 /**
    NSNumber types (integer)
@@ -43,12 +46,12 @@
 /**
    NSArray types
  */
-@property (nonatomic, strong) NSArray *authors;
-@property (nonatomic, strong) NSArray *editors;
-@property (nonatomic, strong) NSArray *translators;
-@property (nonatomic, strong) NSArray *websites;
-@property (nonatomic, strong) NSArray *keywords;
-@property (nonatomic, strong) NSArray *tags;
+@property (nonatomic, strong) NSArray <MendeleyPerson *> *authors;
+@property (nonatomic, strong) NSArray <MendeleyPerson *> *editors;
+@property (nonatomic, strong) NSArray <MendeleyPerson *> *translators;
+@property (nonatomic, strong) NSArray <NSString *> *websites;
+@property (nonatomic, strong) NSArray <NSString *> *keywords;
+@property (nonatomic, strong) NSArray <NSString *> *tags;
 
 /**
    NSDictionary type (Identifiers, e.g. arxiv)

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyDocument.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyDocument.h
@@ -56,7 +56,7 @@
 /**
    NSDictionary type (Identifiers, e.g. arxiv)
  */
-@property (nonatomic, strong) NSDictionary *identifiers;
+@property (nonatomic, strong) NSDictionary <NSString *, NSString *> *identifiers;
 
 /**
    NSDate types (stringDate)

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyGroup.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyGroup.h
@@ -20,7 +20,8 @@
 
 #import "MendeleyObject.h"
 
-@class MendeleyPhoto;
+@class MendeleyPhoto, MendeleyDiscipline
+;
 
 @interface MendeleyGroup : MendeleyObject
 
@@ -32,8 +33,8 @@
 @property (nonatomic, strong) NSString *role;
 @property (nonatomic, strong) MendeleyPhoto *photo;
 @property (nonatomic, strong) NSString *webpage;
-@property (nonatomic, strong) NSArray *disciplines;
-@property (nonatomic, strong) NSArray *tags;
+@property (nonatomic, strong) NSArray <MendeleyDiscipline *> *disciplines;
+@property (nonatomic, strong) NSArray <NSString *> *tags;
 
 @end
 

--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyProfile.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyProfile.h
@@ -33,7 +33,7 @@
 
 @interface MendeleyEmployment : MendeleySecureObject
 
-@property (nonatomic, strong) NSArray *classes;
+@property (nonatomic, strong) NSArray <NSString *> *classes;
 @property (nonatomic, strong) NSString *position;
 @property (nonatomic, strong) NSNumber *is_main_employment;
 @property (nonatomic, strong) NSString *institution;
@@ -62,7 +62,7 @@
 @interface MendeleyDiscipline : MendeleySecureObject
 
 @property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSArray *subdisciplines;
+@property (nonatomic, strong) NSArray <NSString *> *subdisciplines;
 
 @end
 
@@ -88,19 +88,19 @@
 @property (nonatomic, strong) NSString *link;
 @property (nonatomic, strong) NSString *institution;
 @property (nonatomic, strong) NSString *research_interests;
-@property (nonatomic, strong) NSArray *research_interests_list;
+@property (nonatomic, strong) NSArray <NSString *> *research_interests_list;
 @property (nonatomic, strong) NSString *academic_status;
 @property (nonatomic, strong) MendeleyDiscipline *discipline;
-@property (nonatomic, strong) NSArray *disciplines;
+@property (nonatomic, strong) NSArray <MendeleyDiscipline *> *disciplines;
 @property (nonatomic, strong) MendeleyPhoto *photo;
-@property (nonatomic, strong) NSArray *photos;
+@property (nonatomic, strong) NSArray <MendeleyPhoto *> *photos;
 @property (nonatomic, strong) NSNumber *verified;
 @property (nonatomic, strong) NSNumber *marketing;
 @property (nonatomic, strong) NSString *user_type;
 @property (nonatomic, strong) MendeleyLocation *location;
 @property (nonatomic, strong) NSDate *created;
-@property (nonatomic, strong) NSArray *education;
-@property (nonatomic, strong) NSArray *employment;
+@property (nonatomic, strong) NSArray <MendeleyEducation *> *education;
+@property (nonatomic, strong) NSArray <MendeleyEmployment *> *employment;
 @property (nonatomic, strong) NSString *title;
 @property (nonatomic, strong) NSString *biography;
 @end
@@ -134,8 +134,8 @@
 @property (nonatomic, strong) NSString *institution;
 @property (nonatomic, strong) NSString *biography;
 @property (nonatomic, strong) NSNumber *marketing;
-@property (nonatomic, strong) NSArray *disciplines;
-@property (nonatomic, strong) NSArray *research_interests_list;
+@property (nonatomic, strong) NSArray <MendeleyDiscipline *> *disciplines;
+@property (nonatomic, strong) NSArray <NSString *> *research_interests_list;
 
 @end
 

--- a/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLConnectionProvider.m
+++ b/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLConnectionProvider.m
@@ -30,7 +30,7 @@
 #import "MendeleyNSURLRequestUploadHelper.h"
 
 @interface MendeleyNSURLConnectionProvider ()
-@property (nonatomic, strong, readwrite) NSMutableArray *tasks;
+@property (nonatomic, strong, readwrite) NSMutableArray <MendeleyTask *> *tasks;
 @end
 
 @implementation MendeleyNSURLConnectionProvider

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.h
@@ -41,7 +41,7 @@
  */
 
 @property (nonatomic, strong, readonly) NSDate *syncDate;
-@property (nonatomic, strong, readonly) NSDictionary *linkDictionary;
+@property (nonatomic, strong, readonly) NSDictionary <NSString *, NSURL *> *linkDictionary;
 @property (nonatomic, strong, readonly) NSNumber *totalCount;
 @property (nonatomic, strong, readonly) NSString *modelVersion;
 

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.m
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.m
@@ -34,7 +34,7 @@ static NSDateFormatter * headerDateFormatter()
 
 @interface MendeleySyncInfo ()
 @property (nonatomic, strong, readwrite) NSDate *syncDate;
-@property (nonatomic, strong, readwrite) NSDictionary *linkDictionary;
+@property (nonatomic, strong, readwrite) NSDictionary <NSString *, NSURL *> *linkDictionary;
 @property (nonatomic, strong, readwrite) NSNumber *totalCount;
 @property (nonatomic, strong, readwrite) NSString *modelVersion;
 

--- a/MendeleyKit/MendeleyKit/Utils/Activity Log/MendeleyLog.h
+++ b/MendeleyKit/MendeleyKit/Utils/Activity Log/MendeleyLog.h
@@ -59,7 +59,7 @@
    NSDictionary *filters = {@"my log domain" : @(kLogLevelWarning)};
    [[MendeleyLog sharedInstance] setConsoleLogFilters:filters];
  */
-@property (nonatomic, strong) NSDictionary *consoleLogFilters;
+@property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *consoleLogFilters;
 
 typedef NS_ENUM (NSUInteger, MendeleyLogLevel)
 {

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample/DocumentListTableViewController.m
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample/DocumentListTableViewController.m
@@ -23,7 +23,7 @@
 #import "DocumentDetailTableViewController.h"
 
 @interface DocumentListTableViewController ()
-@property (nonatomic, strong) NSArray *documents;
+@property (nonatomic, strong) NSArray <MendeleyDocument *> *documents;
 @end
 
 @implementation DocumentListTableViewController

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample/FilesWithDocumentTableViewController.m
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample/FilesWithDocumentTableViewController.m
@@ -26,8 +26,8 @@
 #define kTitleLabelTag 100
 
 @interface FilesWithDocumentTableViewController ()
-@property (nonatomic, strong) NSArray *documents;
-@property (nonatomic, strong) NSArray *files;
+@property (nonatomic, strong) NSArray <MendeleyDocument *> *documents;
+@property (nonatomic, strong) NSArray <MendeleyFile *> *files;
 @property (nonatomic, strong) UILabel *headerView;
 @end
 

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample/GroupListLazyLoadingTableViewController.m
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample/GroupListLazyLoadingTableViewController.m
@@ -22,7 +22,7 @@
 #import <MendeleyKitiOS/MendeleyKitiOS.h>
 
 @interface GroupListLazyLoadingTableViewController ()
-@property (nonatomic, strong) NSArray *groups;
+@property (nonatomic, strong) NSArray <MendeleyGroup *> *groups;
 @property (nonatomic, strong) NSMutableDictionary *iconDictionary;
 @end
 

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample/GroupListTableViewController.m
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample/GroupListTableViewController.m
@@ -22,7 +22,7 @@
 #import <MendeleyKitiOS/MendeleyKitiOS.h>
 
 @interface GroupListTableViewController ()
-@property (nonatomic, strong) NSArray *groups;
+@property (nonatomic, strong) NSArray <MendeleyGroup *> *groups;
 @end
 
 @implementation GroupListTableViewController

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitOSXExample/AppDelegate.h
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitOSXExample/AppDelegate.h
@@ -30,9 +30,12 @@
 #define kMyClientID          @"<YOUR CLIENT ID>"
 #define kMyClientRedirectURI @"<YOUR REDIRECT URI>"
 
+@class MendeleyDocument;
+
+
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 
-@property (nonatomic, strong) NSArray *documents;
+@property (nonatomic, strong) NSArray <MendeleyDocument *> *documents;
 
 - (IBAction)signOut:(id)sender;
 

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnnotationTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnnotationTests.m
@@ -27,10 +27,10 @@
 
 @interface MendeleyAnnotationTests : MendeleyKitTestBaseClass
 @property (nonatomic, strong) UIColor *color;
-@property (nonatomic, strong) NSDictionary *colorDictionary;
+@property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *colorDictionary;
 
 @property (nonatomic, strong) MendeleyHighlightBox *highlightBox;
-@property (nonatomic, strong) NSDictionary *boxDictionary;
+@property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *boxDictionary;
 @end
 
 @implementation MendeleyAnnotationTests

--- a/MendeleyKit/MendeleyKitTests/MendeleyMockNetworkProvider.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyMockNetworkProvider.m
@@ -35,7 +35,7 @@
 
 
 @interface MendeleyMockNetworkProvider ()
-@property (nonatomic, strong) NSMutableArray *taskArray;
+@property (nonatomic, strong) NSMutableArray <MendeleyTask *> *taskArray;
 @property (nonatomic, assign) NSUInteger taskCounter;
 @property (nonatomic, strong) MendeleyResponse *mockResponse;
 @end

--- a/MendeleyKit/MendeleyKitTests/NSDictionaryMergeCategoryTests.m
+++ b/MendeleyKit/MendeleyKitTests/NSDictionaryMergeCategoryTests.m
@@ -28,8 +28,6 @@
 @property (nonatomic, strong) NSDictionary *mergedDict;
 @property (nonatomic, strong) NSDictionary *nilDict;
 
-
-
 @end
 
 @implementation NSDictionaryMergeCategoryTests
@@ -73,7 +71,6 @@
 
     NSDictionary *staticTestDict = [NSDictionary dictionaryByMerging:self.firstDict with:self.secondDict];
     XCTAssert([staticTestDict isEqualToDictionary:self.mergedDict], @"Merge result is not as expected");
-
 }
 
 - (void)testFirstIsNil
@@ -92,7 +89,5 @@
     NSDictionary *staticTestDict = [NSDictionary dictionaryByMerging:self.firstDict with:self.nilDict];
     XCTAssert([staticTestDict isEqualToDictionary:self.firstDict], @"Merge result is not as expected");
 }
-
-
 
 @end


### PR DESCRIPTION
This pull request adds lightweight generic parameterization for `NSArray` and `NSDictionary` properties.

https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithObjective-CAPIs.html#//apple_ref/doc/uid/TP40014216-CH4-ID35

These annotations improve Objective-C/Swift interoperability, and generate compilation warnings when trying to use an invalid object class with these collections.

