### PR TITLE
Add OS X dynamic framework test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ script:
   - cd MendeleyKit
   - pod install
   - xcodebuild -workspace MendeleyKit.xcworkspace -scheme MendeleyKitiOS -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test
+  - xcodebuild -workspace MendeleyKit.xcworkspace -scheme MendeleyKitOSX test

--- a/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		725CFFE51B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CFFE21B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m */; };
 		725CFFE61B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CFFE21B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m */; };
 		725CFFE71B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CFFE21B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m */; };
+		7A743EA58D75C657D1E53657 /* libPods-MendeleyKitOSXTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 366BF49819F94E01DE1C36DE /* libPods-MendeleyKitOSXTests.a */; };
 		C24E70A3E1A44058A40FBE96 /* libPods-MendeleyKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DEA9B99D5FE40BEB2C9E99F /* libPods-MendeleyKitTests.a */; };
 		C406B3021B611862003040F5 /* MendeleyDefaultAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C406B3011B611862003040F5 /* MendeleyDefaultAnalytics.swift */; };
 		C41474191A7F751500DC01D9 /* MendeleyDisciplineModellerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C41474181A7F751500DC01D9 /* MendeleyDisciplineModellerTest.m */; };
@@ -534,6 +535,58 @@
 		D706C7711D36448200381886 /* MendeleyDatasetModellerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D706C76F1D36448200381886 /* MendeleyDatasetModellerTests.m */; };
 		D7A3C0AF1D490E0B00CF12A9 /* licences.json in Resources */ = {isa = PBXBuildFile; fileRef = D7A3C0AE1D490E0B00CF12A9 /* licences.json */; };
 		D7A3C0B01D490E0B00CF12A9 /* licences.json in Resources */ = {isa = PBXBuildFile; fileRef = D7A3C0AE1D490E0B00CF12A9 /* licences.json */; };
+		D7A3C0E41D4BAE5400CF12A9 /* MendeleyKitOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C42111901A233AC7006C044C /* MendeleyKitOSX.framework */; };
+		D7A3C0EA1D4BAFB600CF12A9 /* MendeleySyncInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885E19DB178000127ECE /* MendeleySyncInfoTests.m */; };
+		D7A3C0EB1D4BAFB600CF12A9 /* MendeleyQueryParameterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885C19DB176C00127ECE /* MendeleyQueryParameterTests.m */; };
+		D7A3C0EC1D4BAFB600CF12A9 /* MendeleyNetworkingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885119DB175500127ECE /* MendeleyNetworkingTests.m */; };
+		D7A3C0ED1D4BAFB600CF12A9 /* MendeleyOAuthStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885219DB175500127ECE /* MendeleyOAuthStoreTests.m */; };
+		D7A3C0EE1D4BAFB600CF12A9 /* MendeleyReachabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885319DB175500127ECE /* MendeleyReachabilityTests.m */; };
+		D7A3C0EF1D4BAFB600CF12A9 /* MendeleyResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885419DB175500127ECE /* MendeleyResponseTests.m */; };
+		D7A3C0F01D4BAFB600CF12A9 /* MendeleySimpleNetworkProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462885519DB175500127ECE /* MendeleySimpleNetworkProviderTests.m */; };
+		D7A3C0F11D4BAFB600CF12A9 /* MendeleyNSURLConnectionProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C47E53AE19EE5D0900D8FF23 /* MendeleyNSURLConnectionProviderTests.m */; };
+		D7A3C0F21D4BAFC100CF12A9 /* NSDictionaryMergeCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884E19DB172E00127ECE /* NSDictionaryMergeCategoryTests.m */; };
+		D7A3C0F31D4BAFC100CF12A9 /* MendeleyErrorCategoriesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884619DB171900127ECE /* MendeleyErrorCategoriesTests.m */; };
+		D7A3C0F41D4BAFC100CF12A9 /* MendeleyErrorManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884719DB171900127ECE /* MendeleyErrorManagerTests.m */; };
+		D7A3C0F51D4BAFC100CF12A9 /* MendeleyLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884819DB171900127ECE /* MendeleyLogTests.m */; };
+		D7A3C0F61D4BAFC100CF12A9 /* MendeleyPerformanceMeterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884919DB171900127ECE /* MendeleyPerformanceMeterTests.m */; };
+		D7A3C0F71D4BAFCC00CF12A9 /* MendeleyMockNetworkProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886D19DB17F100127ECE /* MendeleyMockNetworkProvider.m */; };
+		D7A3C0F81D4BAFCC00CF12A9 /* MendeleyMockNetworkProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886E19DB17F100127ECE /* MendeleyMockNetworkProviderTests.m */; };
+		D7A3C0F91D4BAFCC00CF12A9 /* MendeleyKitConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462883E19DB166B00127ECE /* MendeleyKitConfigurationTests.m */; };
+		D7A3C0FA1D4BAFCC00CF12A9 /* MendeleyKitTestsThreadHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884419DB16B100127ECE /* MendeleyKitTestsThreadHelper.m */; };
+		D7A3C0FB1D4BAFCC00CF12A9 /* MendeleyKitTestBaseClass.m in Sources */ = {isa = PBXBuildFile; fileRef = C462884019DB166B00127ECE /* MendeleyKitTestBaseClass.m */; };
+		D7A3C0FC1D4BAFD200CF12A9 /* MendeleyAcademicStatusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C4F095091AA4771F00C5951C /* MendeleyAcademicStatusTests.m */; };
+		D7A3C0FD1D4BAFD200CF12A9 /* MendeleyAnnotationsAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886919DB17D200127ECE /* MendeleyAnnotationsAPITests.m */; };
+		D7A3C0FF1D4BAFD200CF12A9 /* MendeleyCatalogDocumentsModellerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886019DB17A700127ECE /* MendeleyCatalogDocumentsModellerTests.m */; };
+		D7A3C1001D4BAFD200CF12A9 /* MendeleyDisciplineModellerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C41474181A7F751500DC01D9 /* MendeleyDisciplineModellerTest.m */; };
+		D7A3C1011D4BAFD200CF12A9 /* MendeleyModellerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886119DB17A700127ECE /* MendeleyModellerTest.m */; };
+		D7A3C1021D4BAFD200CF12A9 /* MendeleyModelTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886219DB17A700127ECE /* MendeleyModelTest.m */; };
+		D7A3C1031D4BAFD200CF12A9 /* MendeleyObjectHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886319DB17A700127ECE /* MendeleyObjectHelperTests.m */; };
+		D7A3C1041D4BAFD200CF12A9 /* MendeleyRecentlyReadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C8503FCD1AB06F4D00A56CE7 /* MendeleyRecentlyReadTests.m */; };
+		D7A3C1051D4BAFD200CF12A9 /* MendeleyFollowTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C85463941ADE997C00754160 /* MendeleyFollowTests.m */; };
+		D7A3C1061D4BAFD200CF12A9 /* MendeleyDatasetModellerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D706C76F1D36448200381886 /* MendeleyDatasetModellerTests.m */; };
+		D7A3C1081D4BAFD700CF12A9 /* MendeleyProfilesAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462883919DB164600127ECE /* MendeleyProfilesAPITests.m */; };
+		D7A3C1091D4BAFD700CF12A9 /* MendeleyKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462883A19DB164600127ECE /* MendeleyKitTests.m */; };
+		D7A3C10A1D4BAFDE00CF12A9 /* academic_statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = C4F095071AA474D500C5951C /* academic_statuses.json */; };
+		D7A3C10B1D4BAFDE00CF12A9 /* annotation.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882219DB160700127ECE /* annotation.json */; };
+		D7A3C10C1D4BAFDE00CF12A9 /* catalogue.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882319DB160700127ECE /* catalogue.json */; };
+		D7A3C10D1D4BAFDE00CF12A9 /* catalogueArray.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882419DB160700127ECE /* catalogueArray.json */; };
+		D7A3C10E1D4BAFDE00CF12A9 /* dataset.json in Resources */ = {isa = PBXBuildFile; fileRef = D706C7691D36429600381886 /* dataset.json */; };
+		D7A3C10F1D4BAFDE00CF12A9 /* datasets.json in Resources */ = {isa = PBXBuildFile; fileRef = D706C76A1D36429600381886 /* datasets.json */; };
+		D7A3C1101D4BAFDE00CF12A9 /* disciplines.json in Resources */ = {isa = PBXBuildFile; fileRef = C42AAA2B1A7BCA4700502358 /* disciplines.json */; };
+		D7A3C1111D4BAFDE00CF12A9 /* document.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882519DB160700127ECE /* document.json */; };
+		D7A3C1121D4BAFDE00CF12A9 /* documentList.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882619DB160700127ECE /* documentList.json */; };
+		D7A3C1131D4BAFDE00CF12A9 /* folderContent.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882719DB160700127ECE /* folderContent.json */; };
+		D7A3C1141D4BAFDE00CF12A9 /* folders.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882819DB160700127ECE /* folders.json */; };
+		D7A3C1151D4BAFDE00CF12A9 /* followers.json in Resources */ = {isa = PBXBuildFile; fileRef = C85463971ADE9BCC00754160 /* followers.json */; };
+		D7A3C1161D4BAFDE00CF12A9 /* group.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882A19DB160700127ECE /* group.json */; };
+		D7A3C1171D4BAFDE00CF12A9 /* groupList.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882B19DB160700127ECE /* groupList.json */; };
+		D7A3C1181D4BAFDE00CF12A9 /* licences.json in Resources */ = {isa = PBXBuildFile; fileRef = D7A3C0AE1D490E0B00CF12A9 /* licences.json */; };
+		D7A3C1191D4BAFDE00CF12A9 /* profiles.json in Resources */ = {isa = PBXBuildFile; fileRef = C462882C19DB160700127ECE /* profiles.json */; };
+		D7A3C11A1D4BAFDE00CF12A9 /* recentlyReadArray.json in Resources */ = {isa = PBXBuildFile; fileRef = C8503FCF1AB0725D00A56CE7 /* recentlyReadArray.json */; };
+		D7A3C11B1D4BAFDE00CF12A9 /* recentlyReadObject.json in Resources */ = {isa = PBXBuildFile; fileRef = C8503FD01AB0725D00A56CE7 /* recentlyReadObject.json */; };
+		D7A3C11C1D4BAFDE00CF12A9 /* followRequest.json in Resources */ = {isa = PBXBuildFile; fileRef = 373AA4EA1B4698F800F8B0C4 /* followRequest.json */; };
+		D7A3C11D1D4BAFDE00CF12A9 /* followAcceptance.json in Resources */ = {isa = PBXBuildFile; fileRef = 373AA4EC1B46AAB500F8B0C4 /* followAcceptance.json */; };
+		D7A3C11E1D4BB2E600CF12A9 /* GettingStartedGuide.pdf in Resources */ = {isa = PBXBuildFile; fileRef = C414741A1A7F8FDC00DC01D9 /* GettingStartedGuide.pdf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -550,6 +603,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = C4CD513A19DAD9E400C8EB8D;
 			remoteInfo = MendeleyKit;
+		};
+		D7A3C0E51D4BAE5400CF12A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C4CD513319DAD9E400C8EB8D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C421118F1A233AC7006C044C;
+			remoteInfo = MendeleyKitOSX;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -577,6 +637,7 @@
 		0B387EEC19ED695000ACCBE1 /* MendeleyNSURLRequestUploadHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MendeleyNSURLRequestUploadHelper.h; path = "Networking/NSURLConnection Provider/MendeleyNSURLRequestUploadHelper.h"; sourceTree = "<group>"; };
 		0B387EED19ED695000ACCBE1 /* MendeleyNSURLRequestUploadHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MendeleyNSURLRequestUploadHelper.m; path = "Networking/NSURLConnection Provider/MendeleyNSURLRequestUploadHelper.m"; sourceTree = "<group>"; };
 		0F7FE6F8D2A0E0F2771226C7 /* Pods-MendeleyKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests.release.xcconfig"; sourceTree = "<group>"; };
+		366BF49819F94E01DE1C36DE /* libPods-MendeleyKitOSXTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MendeleyKitOSXTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		373AA4EA1B4698F800F8B0C4 /* followRequest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = followRequest.json; sourceTree = "<group>"; };
 		373AA4EC1B46AAB500F8B0C4 /* followAcceptance.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = followAcceptance.json; sourceTree = "<group>"; };
 		5EDBA7378F567E89727A6D0F /* libPods-MendeleyKitiOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MendeleyKitiOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -589,8 +650,10 @@
 		725CFFDB1B7B408300AC6758 /* MendeleyFeature.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MendeleyFeature.m; path = "Model/Mendeley Objects/MendeleyFeature.m"; sourceTree = "<group>"; };
 		725CFFE11B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MendeleyApplicationFeaturesAPI.h; path = "Public Interface/API Interfaces/MendeleyApplicationFeaturesAPI.h"; sourceTree = "<group>"; };
 		725CFFE21B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MendeleyApplicationFeaturesAPI.m; path = "Public Interface/API Interfaces/MendeleyApplicationFeaturesAPI.m"; sourceTree = "<group>"; };
+		732F0A391959A588D5BAFFCB /* Pods-MendeleyKitOSXTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitOSXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8302971636AF25A993EDBA94 /* Pods-MendeleyKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9DEA9B99D5FE40BEB2C9E99F /* libPods-MendeleyKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MendeleyKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A304643800733756F1157F04 /* Pods-MendeleyKitOSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitOSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests.release.xcconfig"; sourceTree = "<group>"; };
 		C406B3011B611862003040F5 /* MendeleyDefaultAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MendeleyDefaultAnalytics.swift; path = Analytics/MendeleyDefaultAnalytics.swift; sourceTree = "<group>"; };
 		C41474181A7F751500DC01D9 /* MendeleyDisciplineModellerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MendeleyDisciplineModellerTest.m; sourceTree = "<group>"; };
 		C414741A1A7F8FDC00DC01D9 /* GettingStartedGuide.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = GettingStartedGuide.pdf; sourceTree = "<group>"; };
@@ -826,6 +889,8 @@
 		D706C76A1D36429600381886 /* datasets.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = datasets.json; sourceTree = "<group>"; };
 		D706C76F1D36448200381886 /* MendeleyDatasetModellerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MendeleyDatasetModellerTests.m; sourceTree = "<group>"; };
 		D7A3C0AE1D490E0B00CF12A9 /* licences.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = licences.json; sourceTree = "<group>"; };
+		D7A3C0DF1D4BAE5300CF12A9 /* MendeleyKitOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MendeleyKitOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7A3C0E31D4BAE5400CF12A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DFDCE2E92DC2090614D79B17 /* Pods-MendeleyKitiOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitiOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F121F55BE4CD06F6F3C91312 /* Pods-MendeleyKitiOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitiOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -889,6 +954,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D7A3C0DC1D4BAE5300CF12A9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7A3C0E41D4BAE5400CF12A9 /* MendeleyKitOSX.framework in Frameworks */,
+				7A743EA58D75C657D1E53657 /* libPods-MendeleyKitOSXTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -915,6 +989,8 @@
 				0F7FE6F8D2A0E0F2771226C7 /* Pods-MendeleyKitTests.release.xcconfig */,
 				DFDCE2E92DC2090614D79B17 /* Pods-MendeleyKitiOSTests.debug.xcconfig */,
 				F121F55BE4CD06F6F3C91312 /* Pods-MendeleyKitiOSTests.release.xcconfig */,
+				732F0A391959A588D5BAFFCB /* Pods-MendeleyKitOSXTests.debug.xcconfig */,
+				A304643800733756F1157F04 /* Pods-MendeleyKitOSXTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -1348,6 +1424,7 @@
 				C42111911A233AC7006C044C /* MendeleyKitOSX */,
 				C466564D1B3842AF005F762A /* MendeleyKitiOS */,
 				C46656591B3842B0005F762A /* MendeleyKitiOSTests */,
+				D7A3C0E01D4BAE5300CF12A9 /* MendeleyKitOSXTests */,
 				C4CD513D19DAD9E400C8EB8D /* Frameworks */,
 				C4CD513C19DAD9E400C8EB8D /* Products */,
 				BC8B75FE7E591BB0E3D3CA78 /* Pods */,
@@ -1362,6 +1439,7 @@
 				C42111901A233AC7006C044C /* MendeleyKitOSX.framework */,
 				C466564C1B3842AF005F762A /* MendeleyKitiOS.framework */,
 				C46656551B3842B0005F762A /* MendeleyKitiOSTests.xctest */,
+				D7A3C0DF1D4BAE5300CF12A9 /* MendeleyKitOSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1385,6 +1463,7 @@
 				C4CD514F19DAD9E400C8EB8D /* UIKit.framework */,
 				9DEA9B99D5FE40BEB2C9E99F /* libPods-MendeleyKitTests.a */,
 				5EDBA7378F567E89727A6D0F /* libPods-MendeleyKitiOSTests.a */,
+				366BF49819F94E01DE1C36DE /* libPods-MendeleyKitOSXTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1477,6 +1556,14 @@
 				373AA4EC1B46AAB500F8B0C4 /* followAcceptance.json */,
 			);
 			name = "Sample JSON responses";
+			sourceTree = "<group>";
+		};
+		D7A3C0E01D4BAE5300CF12A9 /* MendeleyKitOSXTests */ = {
+			isa = PBXGroup;
+			children = (
+				D7A3C0E31D4BAE5400CF12A9 /* Info.plist */,
+			);
+			path = MendeleyKitOSXTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1754,6 +1841,27 @@
 			productReference = C4CD514B19DAD9E400C8EB8D /* MendeleyKitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D7A3C0DE1D4BAE5300CF12A9 /* MendeleyKitOSXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D7A3C0E91D4BAE5400CF12A9 /* Build configuration list for PBXNativeTarget "MendeleyKitOSXTests" */;
+			buildPhases = (
+				83186CA70A068E44C8081906 /* [CP] Check Pods Manifest.lock */,
+				D7A3C0DB1D4BAE5300CF12A9 /* Sources */,
+				D7A3C0DC1D4BAE5300CF12A9 /* Frameworks */,
+				D7A3C0DD1D4BAE5300CF12A9 /* Resources */,
+				77FB8AEE4B79C0F05257C49A /* [CP] Embed Pods Frameworks */,
+				7964046578F4525B70AC0973 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D7A3C0E61D4BAE5400CF12A9 /* PBXTargetDependency */,
+			);
+			name = MendeleyKitOSXTests;
+			productName = MendeleyKitOSXTests;
+			productReference = D7A3C0DF1D4BAE5300CF12A9 /* MendeleyKitOSXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1761,7 +1869,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Mendeley;
 				TargetAttributes = {
 					C421118F1A233AC7006C044C = {
@@ -1772,6 +1880,9 @@
 					};
 					C46656541B3842B0005F762A = {
 						CreatedOnToolsVersion = 7.0;
+					};
+					D7A3C0DE1D4BAE5300CF12A9 = {
+						CreatedOnToolsVersion = 7.3.1;
 					};
 				};
 			};
@@ -1792,6 +1903,7 @@
 				C421118F1A233AC7006C044C /* MendeleyKitOSX */,
 				C466564B1B3842AF005F762A /* MendeleyKitiOS */,
 				C46656541B3842B0005F762A /* MendeleyKitiOSTests */,
+				D7A3C0DE1D4BAE5300CF12A9 /* MendeleyKitOSXTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1868,6 +1980,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D7A3C0DD1D4BAE5300CF12A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7A3C10E1D4BAFDE00CF12A9 /* dataset.json in Resources */,
+				D7A3C1101D4BAFDE00CF12A9 /* disciplines.json in Resources */,
+				D7A3C1121D4BAFDE00CF12A9 /* documentList.json in Resources */,
+				D7A3C10C1D4BAFDE00CF12A9 /* catalogue.json in Resources */,
+				D7A3C11B1D4BAFDE00CF12A9 /* recentlyReadObject.json in Resources */,
+				D7A3C1141D4BAFDE00CF12A9 /* folders.json in Resources */,
+				D7A3C10B1D4BAFDE00CF12A9 /* annotation.json in Resources */,
+				D7A3C1161D4BAFDE00CF12A9 /* group.json in Resources */,
+				D7A3C1111D4BAFDE00CF12A9 /* document.json in Resources */,
+				D7A3C1181D4BAFDE00CF12A9 /* licences.json in Resources */,
+				D7A3C11E1D4BB2E600CF12A9 /* GettingStartedGuide.pdf in Resources */,
+				D7A3C1191D4BAFDE00CF12A9 /* profiles.json in Resources */,
+				D7A3C11A1D4BAFDE00CF12A9 /* recentlyReadArray.json in Resources */,
+				D7A3C1151D4BAFDE00CF12A9 /* followers.json in Resources */,
+				D7A3C11C1D4BAFDE00CF12A9 /* followRequest.json in Resources */,
+				D7A3C1171D4BAFDE00CF12A9 /* groupList.json in Resources */,
+				D7A3C11D1D4BAFDE00CF12A9 /* followAcceptance.json in Resources */,
+				D7A3C10A1D4BAFDE00CF12A9 /* academic_statuses.json in Resources */,
+				D7A3C10F1D4BAFDE00CF12A9 /* datasets.json in Resources */,
+				D7A3C10D1D4BAFDE00CF12A9 /* catalogueArray.json in Resources */,
+				D7A3C1131D4BAFDE00CF12A9 /* folderContent.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -1901,6 +2041,36 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		77FB8AEE4B79C0F05257C49A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7964046578F4525B70AC0973 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		815E227FAF9B438D8C025191 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1914,6 +2084,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		83186CA70A068E44C8081906 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		AC8836685D97A921CDC3CF3C /* [CP] Embed Pods Frameworks */ = {
@@ -2299,6 +2484,43 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D7A3C0DB1D4BAE5300CF12A9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7A3C1001D4BAFD200CF12A9 /* MendeleyDisciplineModellerTest.m in Sources */,
+				D7A3C1031D4BAFD200CF12A9 /* MendeleyObjectHelperTests.m in Sources */,
+				D7A3C0F91D4BAFCC00CF12A9 /* MendeleyKitConfigurationTests.m in Sources */,
+				D7A3C0F01D4BAFB600CF12A9 /* MendeleySimpleNetworkProviderTests.m in Sources */,
+				D7A3C0FD1D4BAFD200CF12A9 /* MendeleyAnnotationsAPITests.m in Sources */,
+				D7A3C0F61D4BAFC100CF12A9 /* MendeleyPerformanceMeterTests.m in Sources */,
+				D7A3C0EE1D4BAFB600CF12A9 /* MendeleyReachabilityTests.m in Sources */,
+				D7A3C0ED1D4BAFB600CF12A9 /* MendeleyOAuthStoreTests.m in Sources */,
+				D7A3C0F31D4BAFC100CF12A9 /* MendeleyErrorCategoriesTests.m in Sources */,
+				D7A3C1081D4BAFD700CF12A9 /* MendeleyProfilesAPITests.m in Sources */,
+				D7A3C1051D4BAFD200CF12A9 /* MendeleyFollowTests.m in Sources */,
+				D7A3C0EA1D4BAFB600CF12A9 /* MendeleySyncInfoTests.m in Sources */,
+				D7A3C0FC1D4BAFD200CF12A9 /* MendeleyAcademicStatusTests.m in Sources */,
+				D7A3C0FB1D4BAFCC00CF12A9 /* MendeleyKitTestBaseClass.m in Sources */,
+				D7A3C0F51D4BAFC100CF12A9 /* MendeleyLogTests.m in Sources */,
+				D7A3C0F81D4BAFCC00CF12A9 /* MendeleyMockNetworkProviderTests.m in Sources */,
+				D7A3C0FF1D4BAFD200CF12A9 /* MendeleyCatalogDocumentsModellerTests.m in Sources */,
+				D7A3C0F21D4BAFC100CF12A9 /* NSDictionaryMergeCategoryTests.m in Sources */,
+				D7A3C1041D4BAFD200CF12A9 /* MendeleyRecentlyReadTests.m in Sources */,
+				D7A3C1011D4BAFD200CF12A9 /* MendeleyModellerTest.m in Sources */,
+				D7A3C0F71D4BAFCC00CF12A9 /* MendeleyMockNetworkProvider.m in Sources */,
+				D7A3C1061D4BAFD200CF12A9 /* MendeleyDatasetModellerTests.m in Sources */,
+				D7A3C0EF1D4BAFB600CF12A9 /* MendeleyResponseTests.m in Sources */,
+				D7A3C0EB1D4BAFB600CF12A9 /* MendeleyQueryParameterTests.m in Sources */,
+				D7A3C0F41D4BAFC100CF12A9 /* MendeleyErrorManagerTests.m in Sources */,
+				D7A3C1091D4BAFD700CF12A9 /* MendeleyKitTests.m in Sources */,
+				D7A3C0FA1D4BAFCC00CF12A9 /* MendeleyKitTestsThreadHelper.m in Sources */,
+				D7A3C0F11D4BAFB600CF12A9 /* MendeleyNSURLConnectionProviderTests.m in Sources */,
+				D7A3C1021D4BAFD200CF12A9 /* MendeleyModelTest.m in Sources */,
+				D7A3C0EC1D4BAFB600CF12A9 /* MendeleyNetworkingTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2311,6 +2533,11 @@
 			isa = PBXTargetDependency;
 			target = C4CD513A19DAD9E400C8EB8D /* MendeleyKit */;
 			targetProxy = C4CD515119DAD9E400C8EB8D /* PBXContainerItemProxy */;
+		};
+		D7A3C0E61D4BAE5400CF12A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C421118F1A233AC7006C044C /* MendeleyKitOSX */;
+			targetProxy = D7A3C0E51D4BAE5400CF12A9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2352,6 +2579,7 @@
 				MODULE_NAME = com.mendeley.MendeleyKit;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				New_Setting = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2383,6 +2611,7 @@
 				MODULE_NAME = com.mendeley.MendeleyKit;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				New_Setting = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2423,7 +2652,7 @@
 				MODULE_NAME = com.mendeley.MendeleyKit;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2462,7 +2691,7 @@
 				MODULE_NAME = com.mendeley.MendeleyKit;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2538,6 +2767,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -2643,6 +2873,7 @@
 				);
 				INFOPLIST_FILE = "MendeleyKitTests/MendeleyKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "MendeleyKitTests/MendeleyKitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -2664,9 +2895,54 @@
 				GCC_PREFIX_HEADER = "MendeleyKit/MendeleyKit-Prefix.pch";
 				INFOPLIST_FILE = "MendeleyKitTests/MendeleyKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "MendeleyKitTests/MendeleyKitTests-Bridging-Header.h";
 				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		D7A3C0E71D4BAE5400CF12A9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 732F0A391959A588D5BAFFCB /* Pods-MendeleyKitOSXTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MendeleyKitOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitOSXTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		D7A3C0E81D4BAE5400CF12A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A304643800733756F1157F04 /* Pods-MendeleyKitOSXTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MendeleyKitOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitOSXTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -2723,6 +2999,15 @@
 			buildConfigurations = (
 				C4CD516219DAD9E400C8EB8D /* Debug */,
 				C4CD516319DAD9E400C8EB8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D7A3C0E91D4BAE5400CF12A9 /* Build configuration list for PBXNativeTarget "MendeleyKitOSXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D7A3C0E71D4BAE5400CF12A9 /* Debug */,
+				D7A3C0E81D4BAE5400CF12A9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
@@ -533,6 +533,11 @@
 		D706C76E1D36429600381886 /* datasets.json in Resources */ = {isa = PBXBuildFile; fileRef = D706C76A1D36429600381886 /* datasets.json */; };
 		D706C7701D36448200381886 /* MendeleyDatasetModellerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D706C76F1D36448200381886 /* MendeleyDatasetModellerTests.m */; };
 		D706C7711D36448200381886 /* MendeleyDatasetModellerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D706C76F1D36448200381886 /* MendeleyDatasetModellerTests.m */; };
+		D759044C1D5327E000A6B1DF /* MendeleyAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43B653F1B66496800B878ED /* MendeleyAnalyticsTests.swift */; };
+		D759044D1D53288A00A6B1DF /* MendeleyKitLoginHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415E9E41B3ACDFE00C937E3 /* MendeleyKitLoginHelperTests.swift */; };
+		D759044E1D5328BF00A6B1DF /* MendeleyKitLoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46656271B37F239005F762A /* MendeleyKitLoginHelper.swift */; };
+		D759044F1D5329B800A6B1DF /* MendeleyAnnotationModellerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C462886819DB17D200127ECE /* MendeleyAnnotationModellerTest.m */; };
+		D75904501D532A3E00A6B1DF /* MendeleyAnnotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C462883819DB164600127ECE /* MendeleyAnnotationTests.m */; };
 		D7A3C0AF1D490E0B00CF12A9 /* licences.json in Resources */ = {isa = PBXBuildFile; fileRef = D7A3C0AE1D490E0B00CF12A9 /* licences.json */; };
 		D7A3C0B01D490E0B00CF12A9 /* licences.json in Resources */ = {isa = PBXBuildFile; fileRef = D7A3C0AE1D490E0B00CF12A9 /* licences.json */; };
 		D7A3C0E41D4BAE5400CF12A9 /* MendeleyKitOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C42111901A233AC7006C044C /* MendeleyKitOSX.framework */; };
@@ -2208,6 +2213,7 @@
 				C42111EB1A2341A9006C044C /* MendeleyMetadataAPI.m in Sources */,
 				D706C7601D33F35D00381886 /* MendeleyDatasetsAPI.m in Sources */,
 				C48EF2051B735EA90023916F /* MendeleyAnalyticsCacheManager.swift in Sources */,
+				D759044E1D5328BF00A6B1DF /* MendeleyKitLoginHelper.swift in Sources */,
 				C42111EC1A2341A9006C044C /* MendeleyObjectAPI.m in Sources */,
 				C42111ED1A2341A9006C044C /* MendeleyProfilesAPI.m in Sources */,
 				C48EF2071B735EB00023916F /* MendeleyDefaultAnalytics.swift in Sources */,
@@ -2495,12 +2501,15 @@
 				D7A3C0FD1D4BAFD200CF12A9 /* MendeleyAnnotationsAPITests.m in Sources */,
 				D7A3C0F61D4BAFC100CF12A9 /* MendeleyPerformanceMeterTests.m in Sources */,
 				D7A3C0EE1D4BAFB600CF12A9 /* MendeleyReachabilityTests.m in Sources */,
+				D759044C1D5327E000A6B1DF /* MendeleyAnalyticsTests.swift in Sources */,
 				D7A3C0ED1D4BAFB600CF12A9 /* MendeleyOAuthStoreTests.m in Sources */,
+				D759044D1D53288A00A6B1DF /* MendeleyKitLoginHelperTests.swift in Sources */,
 				D7A3C0F31D4BAFC100CF12A9 /* MendeleyErrorCategoriesTests.m in Sources */,
 				D7A3C1081D4BAFD700CF12A9 /* MendeleyProfilesAPITests.m in Sources */,
 				D7A3C1051D4BAFD200CF12A9 /* MendeleyFollowTests.m in Sources */,
 				D7A3C0EA1D4BAFB600CF12A9 /* MendeleySyncInfoTests.m in Sources */,
 				D7A3C0FC1D4BAFD200CF12A9 /* MendeleyAcademicStatusTests.m in Sources */,
+				D75904501D532A3E00A6B1DF /* MendeleyAnnotationTests.m in Sources */,
 				D7A3C0FB1D4BAFCC00CF12A9 /* MendeleyKitTestBaseClass.m in Sources */,
 				D7A3C0F51D4BAFC100CF12A9 /* MendeleyLogTests.m in Sources */,
 				D7A3C0F81D4BAFCC00CF12A9 /* MendeleyMockNetworkProviderTests.m in Sources */,
@@ -2512,6 +2521,7 @@
 				D7A3C1061D4BAFD200CF12A9 /* MendeleyDatasetModellerTests.m in Sources */,
 				D7A3C0EF1D4BAFB600CF12A9 /* MendeleyResponseTests.m in Sources */,
 				D7A3C0EB1D4BAFB600CF12A9 /* MendeleyQueryParameterTests.m in Sources */,
+				D759044F1D5329B800A6B1DF /* MendeleyAnnotationModellerTest.m in Sources */,
 				D7A3C0F41D4BAFC100CF12A9 /* MendeleyErrorManagerTests.m in Sources */,
 				D7A3C1091D4BAFD700CF12A9 /* MendeleyKitTests.m in Sources */,
 				D7A3C0FA1D4BAFCC00CF12A9 /* MendeleyKitTestsThreadHelper.m in Sources */,

--- a/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKit.xcscheme
+++ b/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,15 +39,18 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSX.xcscheme
+++ b/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C42111991A233AC7006C044C"
+               BlueprintIdentifier = "D7A3C0DE1D4BAE5300CF12A9"
                BuildableName = "MendeleyKitOSXTests.xctest"
                BlueprintName = "MendeleyKitOSXTests"
                ReferencedContainer = "container:MendeleyKit.xcodeproj">
@@ -37,16 +37,16 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C42111991A233AC7006C044C"
+               BlueprintIdentifier = "D7A3C0DE1D4BAE5300CF12A9"
                BuildableName = "MendeleyKitOSXTests.xctest"
                BlueprintName = "MendeleyKitOSXTests"
                ReferencedContainer = "container:MendeleyKit.xcodeproj">
@@ -62,24 +62,36 @@
             ReferencedContainer = "container:MendeleyKitExample/MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C421118F1A233AC7006C044C"
+            BuildableName = "MendeleyKitOSX.framework"
+            BlueprintName = "MendeleyKitOSX"
+            ReferencedContainer = "container:MendeleyKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitiOS.xcscheme
+++ b/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
@@ -18,7 +18,6 @@
 *****************************************************************************
 */
 
-import UIKit
 import Foundation
 
 public class MendeleyKitLoginHelper: NSObject

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 		C4A1346619DADB010069DB7A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Mendeley;
 				TargetAttributes = {
 					145C2DB11A2CA84A0005BFF6 = {
@@ -379,6 +379,7 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -405,6 +406,7 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -428,6 +430,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -494,6 +497,7 @@
 				INFOPLIST_FILE = "MendeleyKitExample/MendeleyKitExample-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -513,6 +517,7 @@
 				INFOPLIST_FILE = "MendeleyKitExample/MendeleyKitExample-Info.plist";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitExample.xcscheme
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C4A1346D19DADB010069DB7A"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C4A1346D19DADB010069DB7A"

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSXExample.xcscheme
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSXExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "145C2DB11A2CA84A0005BFF6"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "145C2DB11A2CA84A0005BFF6"

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample/MendeleyKitExample-Info.plist
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample/MendeleyKitExample-Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mendeley.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitOSXExample/Info.plist
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitOSXExample/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mendeley.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MendeleyKit/MendeleyKitOSX/Info.plist
+++ b/MendeleyKit/MendeleyKitOSX/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mendeley.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MendeleyKit/MendeleyKitOSXTests/Info.plist
+++ b/MendeleyKit/MendeleyKitOSXTests/Info.plist
@@ -5,11 +5,13 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>

--- a/MendeleyKit/MendeleyKitTests/MendeleyAcademicStatusTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAcademicStatusTests.m
@@ -19,7 +19,6 @@
  */
 
 //#import <UIKit/UIKit.h>
-@import UIKit;
 
 #import <XCTest/XCTest.h>
 #import "MendeleyKitTestBaseClass.h"

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
@@ -1,23 +1,38 @@
-//
-//  MendeleyAnalyticsTests.swift
-//  MendeleyKit
-//
-//  Created by Peter Schmidt on 27/07/2015.
-//  Copyright © 2015 Mendeley. All rights reserved.
-//
+/*
+ ******************************************************************************
+ * Copyright (C) 2014-2017 Elsevier/Mendeley.
+ *
+ * This file is part of the Mendeley iOS SDK.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************
+ */
 
 import XCTest
+#if os(iOS)
 import MendeleyKitiOS
+#elseif os(OSX)
+import MendeleyKitOSX
+#endif
 
 class MendeleyAnalyticsTests: XCTestCase {
-    
+
     let manager = MendeleyAnalyticsCacheManager()
-    
+
     override func setUp() {
         super.setUp()
-        
     }
-    
+
     override func tearDown() {
         manager.clearCache()
         super.tearDown()
@@ -74,7 +89,6 @@ class MendeleyAnalyticsTests: XCTestCase {
             XCTAssertTrue(name == event.name,"expected name \(name) but got \(event.name)")
             XCTAssertTrue(profile == event.profile_uuid,"expected name \(profile) but got \(event.profile_uuid)")
         }
-
     }
     
     func testLogEvent()
@@ -82,9 +96,8 @@ class MendeleyAnalyticsTests: XCTestCase {
         let analytics = MendeleyDefaultAnalytics.sharedInstance
         let profileID = NSUUID().UUIDString
         analytics.configureMendeleyAnalytics(profileID, clientVersionString: "2.6.0", clientIdentityString: "7")
-        
+
         analytics.logMendeleyAnalyticsEvent("TestPDFEvent")
-        
 
         let cachedEvents = manager.eventsFromArchive()
         XCTAssertTrue(0 < cachedEvents.count, "We should have at least 1 event but got \(cachedEvents.count)")
@@ -94,8 +107,6 @@ class MendeleyAnalyticsTests: XCTestCase {
             XCTAssertTrue(returnedEvent.profile_uuid == profileID, "expected profile ID\(profileID) but got \(returnedEvent.profile_uuid)")
             XCTAssertTrue(returnedEvent.name == "TestPDFEvent", "Expected name 'TestPDFEvent' but got \(returnedEvent.name)")
         }
-        
-        
     }
     
     func testLogEvents()
@@ -113,7 +124,5 @@ class MendeleyAnalyticsTests: XCTestCase {
         analytics.logMendeleyAnalyticsEvents(array)
         let cachedEvents = manager.eventsFromArchive()
         XCTAssertTrue(20 == cachedEvents.count, "We should have 20 events but got \(cachedEvents.count)")
-        
     }
-    
 }

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnnotationModellerTest.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnnotationModellerTest.m
@@ -79,6 +79,8 @@
                              XCTAssertTrue([annotation.document_id isEqualToString:@"68e3bce9-4c35-3e8d-aa79-b007f50405a4"], @"Unexpected document ID");
                              XCTAssertTrue([annotation.filehash isEqualToString:@"4787da46c9b91cb69f7f3449e20b210fe970e234"], @"Unexpected filehash");
                              XCTAssertTrue([annotation.privacy_level isEqualToString:@"private"], @"Unexpected privacy_level");
+
+#if TARGET_OS_IPHONE
                              id color = annotation.color;
                              XCTAssertTrue([color isKindOfClass:[UIColor class]], @"For iOS this should be a UIColor object");
                              if ([color isKindOfClass:[UIColor class]])
@@ -93,6 +95,7 @@
                                  XCTAssertTrue(232.f == floorf(green), @"green should be 232 but is %f", green);
                                  XCTAssertTrue(116.f == floorf(blue), @"blue should be 116 but is %f", blue);
                              }
+#endif
                              NSArray *positions = annotation.positions;
                              XCTAssertNotNil(positions, @"positions should not be nil");
                              XCTAssertTrue(0 < positions.count, @"We should have a few annotation positions in there");
@@ -140,8 +143,10 @@
 
     annotation.object_ID = @"eb74f036-dd94-4632-b37d-2d80cd207fa4";
     annotation.type = @"highlight";
+#if TARGET_OS_IPHONE
     UIColor *color = [UIColor colorWithRed:248.f / 255.f green:232.f / 255.f blue:116.f / 255.f alpha:1.0f];
     annotation.color = color;
+#endif
 
     annotation.profile_id = @"1b17179a-08d6-342b-a63d-ab0a9264aac8";
     CGFloat topX = 168.6518f;

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnnotationTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnnotationTests.m
@@ -26,7 +26,9 @@
 #import "MendeleyKitTestBaseClass.h"
 
 @interface MendeleyAnnotationTests : MendeleyKitTestBaseClass
+#if TARGET_OS_IPHONE
 @property (nonatomic, strong) UIColor *color;
+#endif
 @property (nonatomic, strong) NSDictionary <NSString *, NSNumber *> *colorDictionary;
 
 @property (nonatomic, strong) MendeleyHighlightBox *highlightBox;
@@ -39,7 +41,9 @@
 {
     [super setUp];
 
+#if TARGET_OS_IPHONE
     self.color = [UIColor colorWithRed:248.f / 255.f green:232.f / 255.f blue:116.f / 255.f alpha:1.f];
+#endif
 
     CGFloat x = 145.3185;
     CGFloat y = 701.9816;
@@ -52,18 +56,15 @@
                               kMendeleyJSONColorGreen : [NSNumber numberWithInt:232],
                               kMendeleyJSONColorBlue : [NSNumber numberWithInt:116] };
 
-
     NSDictionary *topLeft = @{ kMendeleyJSONPositionX : [NSNumber numberWithFloat:145.3185],
                                kMendeleyJSONPositionY : [NSNumber numberWithFloat:701.9816] };
 
     NSDictionary *bottomRight = @{ kMendeleyJSONPositionX : [NSNumber numberWithFloat:145.3185],
                                    kMendeleyJSONPositionY : [NSNumber numberWithFloat:701.9816] };
 
-
     self.boxDictionary = @{ kMendeleyJSONPage : [NSNumber numberWithInt:1],
                             kMendeleyJSONTopLeft : topLeft,
                             kMendeleyJSONBottomRight : bottomRight };
-
 }
 
 - (void)tearDown
@@ -72,6 +73,7 @@
     [super tearDown];
 }
 
+#if TARGET_OS_IPHONE
 - (void)testColorFromColorParameters
 {
     NSError *error = nil;
@@ -98,15 +100,15 @@
     NSDictionary *dictionary = [MendeleyAnnotation jsonColorFromColor:self.color error:&error];
 
     XCTAssertNotNil(dictionary, @"dictionary should not be nil");
-    NSNumber *red = [dictionary objectForKey:kMendeleyJSONColorRed];
-    NSNumber *green = [dictionary objectForKey:kMendeleyJSONColorGreen];
-    NSNumber *blue = [dictionary objectForKey:kMendeleyJSONColorBlue];
+    NSNumber *red = dictionary[kMendeleyJSONColorRed];
+    NSNumber *green = dictionary[kMendeleyJSONColorGreen];
+    NSNumber *blue = dictionary[kMendeleyJSONColorBlue];
 
     XCTAssertTrue(248.f == floorf([red floatValue]), @"red should be 248 but is %f", [red floatValue]);
     XCTAssertTrue(232.f == floorf([green floatValue]), @"red should be 232 but is %f", [green floatValue]);
     XCTAssertTrue(116.f == floorf([blue floatValue]), @"red should be 116 but is %f", [blue floatValue]);
-
 }
+#endif
 
 - (void)testBoxFromJSONParameters
 {
@@ -116,13 +118,11 @@
     XCTAssertNotNil(box, @"we should get a not nil box back");
     XCTAssertNotNil(box.page, @"box page should not be nil");
 
-
     XCTAssertTrue([box.page isEqualToNumber:self.highlightBox.page], @"the highlight box page should be 1");
     CGFloat x = box.box.origin.x;
     CGFloat y = box.box.origin.y;
     CGFloat width = box.box.size.width;
     CGFloat height = box.box.size.height;
-
 
     XCTAssertTrue(145.3185f == x, @"x should be 145.3185 but is %f", x);
     XCTAssertTrue(701.9816f == y, @"y should be 701.9816 but is %f", y);
@@ -137,9 +137,9 @@
 
     XCTAssertNotNil(dict, @"the dictionary should not be nil");
 
-    NSNumber *page = [dict objectForKey:kMendeleyJSONPage];
-    id topLeft = [dict objectForKey:kMendeleyJSONTopLeft];
-    id botRight = [dict objectForKey:kMendeleyJSONBottomRight];
+    NSNumber *page = dict[kMendeleyJSONPage];
+    id topLeft = dict[kMendeleyJSONTopLeft];
+    id botRight = dict[kMendeleyJSONBottomRight];
 
     XCTAssertNotNil(page, @"the page object should not be nil");
     XCTAssertNotNil(topLeft, @"the top_left object should not be nil");
@@ -147,15 +147,15 @@
 
     if (nil != page)
     {
-        XCTAssertTrue(1 == [page intValue], @"page should be 1 but is %d", [page intValue]);
+        XCTAssertEqual(1, [page intValue], @"page should be 1 but is %d", [page intValue]);
     }
 
     if (nil != topLeft)
     {
         XCTAssertTrue([topLeft isKindOfClass:[NSDictionary class]], @"topleft should be of type NSDictionary");
         NSDictionary *dictionary = (NSDictionary *) topLeft;
-        NSNumber *xNumber = [dictionary objectForKey:kMendeleyJSONPositionX];
-        NSNumber *yNumber = [dictionary objectForKey:kMendeleyJSONPositionY];
+        NSNumber *xNumber = dictionary[kMendeleyJSONPositionX];
+        NSNumber *yNumber = dictionary[kMendeleyJSONPositionY];
 
         XCTAssertTrue(145.3185f == [xNumber floatValue], @"x should be 145.3185f but is %f", [xNumber floatValue]);
         XCTAssertTrue(701.9816f == [yNumber floatValue], @"y should be 701.9816f but is %f", [yNumber floatValue]);
@@ -165,14 +165,12 @@
     {
         XCTAssertTrue([botRight isKindOfClass:[NSDictionary class]], @"botRight should be of type NSDictionary");
         NSDictionary *dictionary = (NSDictionary *) botRight;
-        NSNumber *xNumber = [dictionary objectForKey:kMendeleyJSONPositionX];
-        NSNumber *yNumber = [dictionary objectForKey:kMendeleyJSONPositionY];
+        NSNumber *xNumber = dictionary[kMendeleyJSONPositionX];
+        NSNumber *yNumber = dictionary[kMendeleyJSONPositionY];
 
         XCTAssertTrue(145.3185f == [xNumber floatValue], @"x should be 145.3185f but is %f", [xNumber floatValue]);
         XCTAssertTrue(701.9816f == [yNumber floatValue], @"y should be 701.9816f but is %f", [yNumber floatValue]);
     }
-
-
 }
 
 @end

--- a/MendeleyKit/MendeleyKitTests/MendeleyDisciplineModellerTest.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyDisciplineModellerTest.m
@@ -18,7 +18,6 @@
  *****************************************************************************
  */
 
-#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 #ifndef MendeleyKitiOSFramework
 #import "MendeleyModeller.h"

--- a/MendeleyKit/MendeleyKitTests/MendeleyFollowTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyFollowTests.m
@@ -18,8 +18,7 @@
  *****************************************************************************
  */
 
-#import <UIKit/UIKit.h>
-//#import <XCTest/XCTest.h>
+#import <XCTest/XCTest.h>
 
 #import "MendeleyKitTestBaseClass.h"
 

--- a/MendeleyKit/MendeleyKitTests/MendeleyKitLoginHelperTests.swift
+++ b/MendeleyKit/MendeleyKitTests/MendeleyKitLoginHelperTests.swift
@@ -1,63 +1,65 @@
-//
-//  MendeleyKitLoginHelperTests.swift
-//  MendeleyKit
-//
-//  Created by Peter Schmidt on 24/06/2015.
-//  Copyright © 2015 Mendeley. All rights reserved.
-//
+/*
+ ******************************************************************************
+ * Copyright (C) 2014-2017 Elsevier/Mendeley.
+ *
+ * This file is part of the Mendeley iOS SDK.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************
+ */
 
 import XCTest
+#if os(iOS)
 import MendeleyKitiOS
+#elseif os(OSX)
+import MendeleyKitOSX
+#endif
 
 class MendeleyKitLoginHelperTests: XCTestCase
 {
-    
     override func setUp()
     {
         super.setUp()
     }
-    
+
     override func tearDown()
     {
         super.tearDown()
     }
-    
+
     func testGetOAuthRequest()
     {
         let helper = MendeleyKitLoginHelper()
         let request = helper.getOAuthRequest("http://redirect", clientID: "somenumber")
-        
+
         XCTAssertEqual(request.HTTPMethod!, "GET", "http method should be GET")
         let header = request.allHTTPHeaderFields
         XCTAssertNotNil(header, "header should not be nil")
-        
+
         let url = request.URL
         XCTAssertNotNil(url, "request url should not be nil")
-        
     }
-    
-    
+
     func testAuthenticationCodeFromRequest()
     {
         let url = NSURL(string: "http://localhost/auth_return?code=1234")
-        
         let helper = MendeleyKitLoginHelper()
-        
         let codeString = helper.getAuthenticationCode(url!)
-        
-        
+
         XCTAssertNotNil(codeString, "We should get a string back")
         if nil != codeString
         {
             XCTAssertTrue(codeString! == "1234", "We should get back '1234' but instead get \(codeString)")
         }
     }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock() {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
 }

--- a/MendeleyKit/MendeleyKitTests/MendeleyKitTestsBaseInclude.h
+++ b/MendeleyKit/MendeleyKitTests/MendeleyKitTestsBaseInclude.h
@@ -22,8 +22,11 @@
 #define MendeleyKitTestsBaseInclude_h
 
 //#ifdef MendeleyKitiOSFramework
+#if TARGET_OS_IPHONE
 @import MendeleyKitiOS;
-//#endif
+#else
+@import MendeleyKitOSX;
+#endif
 
 
 #endif /* MendeleyKitTestsBaseInclude_h */

--- a/MendeleyKit/MendeleyKitTests/MendeleyNSURLConnectionProviderTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyNSURLConnectionProviderTests.m
@@ -18,7 +18,6 @@
  *****************************************************************************
  */
 
-#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 #import "MendeleyKitTestBaseClass.h"
 

--- a/MendeleyKit/MendeleyKitTests/MendeleyRecentlyReadTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyRecentlyReadTests.m
@@ -18,7 +18,6 @@
  *****************************************************************************
  */
 
-#import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 #import "MendeleyKitTestBaseClass.h"
 

--- a/MendeleyKit/MendeleyKitiOS/Info.plist
+++ b/MendeleyKit/MendeleyKitiOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mendeley.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MendeleyKit/Podfile
+++ b/MendeleyKit/Podfile
@@ -1,11 +1,15 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
 
 target :MendeleyKitTests  do
     pod 'OCMock'
 end
 
 target :MendeleyKitiOSTests do
+	platform :ios, '8.0'
     pod 'OCMock'
 end
 
+target :MendeleyKitOSXTests do
+	platform :osx, '10.9'
+    pod 'OCMock'
+end


### PR DESCRIPTION
This pull-request adds a new test target for the OS X dynamic framework. This new target directly runs the test cases from the original iOS test target, with a couple of minor adjustments when the code isn't directly cross-platforms (e.g. `UIColor` instead of `NSColor`).

It updates the Travis CI configuration as well, to now test both targets (iOS and OS X). Example: https://travis-ci.org/vtourraine/mendeleykit/builds/149711817

This pull-request also updates the existing `testActivityLogLimit` test method to handle the asynchronous nature of logging (as discussed in pull-request #49, otherwise the test can produce inconsistent results).