### PR TITLE
Fix nullability annotation

### DIFF
--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginHandleriOS7.m
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginHandleriOS7.m
@@ -90,7 +90,7 @@
     
 }
 
-- (void)webView:(nonnull UIWebView *)webView didFailLoadWithError:(nullable NSError *)error
+- (void)webView:(nonnull UIWebView *)webView didFailLoadWithError:(nonnull NSError *)error
 {
     NSDictionary *userInfo = [error userInfo];
     NSString *failingURLString = [userInfo objectForKey:NSURLErrorFailingURLStringErrorKey];


### PR DESCRIPTION
Fix nullability annotation when implementing the `UIWebViewDelegate` protocol

Depending on the project settings, this can throw a compilation error:

```
MendeleyLoginHandleriOS7.m:[93,87] nullability specifier 'nullable' conflicts with existing specifier 'nonnull'
```