### PR TITLE
Update dataset modeller to support categories, links, licence

### DIFF
--- a/MendeleyKit/MendeleyKit/MendeleyGlobals.h
+++ b/MendeleyKit/MendeleyKit/MendeleyGlobals.h
@@ -483,6 +483,9 @@ typedef void (^ __nullable MendeleyStringArrayCompletionBlock)(NSArray * __nulla
 #define kMendeleyJSONCategories                           @"categories"
 #define kMendeleyJSONInstitutions                         @"institutions"
 #define kMendeleyJSONRelatedLinks                         @"related_links"
+#define kMendeleyJSONRelatedLinksRel                      @"rel"
+#define kMendeleyJSONRelatedLinksType                     @"type"
+#define kMendeleyJSONRelatedLinksHref                     @"href"
 
 /***********************************************
  @name JSON keys File metadata

--- a/MendeleyKit/MendeleyKit/Model/MendeleyModeller.m
+++ b/MendeleyKit/MendeleyKit/Model/MendeleyModeller.m
@@ -184,7 +184,11 @@
              NSString *matchedName = [MendeleyObjectHelper matchedJSONKeyForKey:name];
              if ([MendeleyObjectHelper isCustomizableModelObject:model forPropertyName:name error:error])
              {
-                 [properties setObject:[MendeleyObjectHelper rawValueFromCustomObject:value modelObject:model propertyName:name error:error] forKey:matchedName];
+                 id rawValue = [MendeleyObjectHelper rawValueFromCustomObject:value modelObject:model propertyName:name error:error];
+                 if (rawValue != nil)
+                 {
+                     [properties setObject:rawValue forKey:matchedName];
+                 }
              }
 
              else if ([value isKindOfClass:[NSDate class]])

--- a/MendeleyKit/MendeleyKit/Model/MendeleyObjectHelper.m
+++ b/MendeleyKit/MendeleyKit/Model/MendeleyObjectHelper.m
@@ -1348,18 +1348,63 @@
         {
             NSArray *filesMetadata = (NSArray *)customObject;
             NSMutableArray *filesDicts = [NSMutableArray arrayWithCapacity:filesMetadata.count];
-            for (MendeleyFileMetadata *metadata in filesMetadata) {
+            for (MendeleyFileMetadata *metadata in filesMetadata)
+            {
                 NSMutableDictionary *fileDict = [NSMutableDictionary dictionary];
-                if (metadata.filename) {
+                if (metadata.filename)
+                {
                     fileDict[NSStringFromSelector(@selector(filename))] = metadata.filename;
                 }
-                if (metadata.content_details) {
+                if (metadata.content_details)
+                {
                     fileDict[kMendeleyJSONContentDetails] = [self rawValueFromCustomObject:metadata.content_details modelObject:metadata propertyName:kMendeleyJSONContentDetails error:nil];
                 }
                 [filesDicts addObject:fileDict];
             }
 
             return filesDicts;
+        }
+        else if ([propertyName isEqualToString:kMendeleyJSONCategories] && [customObject isKindOfClass:[NSArray class]])
+        {
+            NSArray *categories = (NSArray *)customObject;
+            NSMutableArray *categoriesDicts = [NSMutableArray arrayWithCapacity:categories.count];
+            for (MendeleyCategory *category in categories)
+            {
+                if (category.object_ID)
+                {
+                    [categoriesDicts addObject:@{kMendeleyJSONID: category.object_ID}];
+                }
+            }
+
+            return categoriesDicts;
+        }
+        else if ([propertyName isEqualToString:kMendeleyJSONRelatedLinks] && [customObject isKindOfClass:[NSArray class]])
+        {
+            NSArray *relatedLinks = (NSArray *)customObject;
+            NSMutableArray *relatedLinksDicts = [NSMutableArray arrayWithCapacity:relatedLinks.count];
+            for (MendeleyRelatedLink *relatedLink in relatedLinks)
+            {
+                NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+                if (relatedLink.rel != nil)
+                {
+                    dictionary[kMendeleyJSONRelatedLinksRel] = relatedLink.rel;
+                }
+                if (relatedLink.type != nil)
+                {
+                    dictionary[kMendeleyJSONRelatedLinksType] = relatedLink.type;
+                }
+                if (relatedLink.href != nil)
+                {
+                    dictionary[kMendeleyJSONRelatedLinksHref] = relatedLink.href;
+                }
+                [relatedLinksDicts addObject:dictionary];
+            }
+
+            return relatedLinksDicts;
+        }
+        else if ([propertyName isEqualToString:kMendeleyJSONDataLicence] && [customObject isKindOfClass:[MendeleyLicenceInfo class]] && ((MendeleyLicenceInfo *)customObject).object_ID)
+        {
+            return @{kMendeleyJSONID: ((MendeleyLicenceInfo *)customObject).object_ID};
         }
     }
 

--- a/MendeleyKit/MendeleyKitTests/MendeleyDatasetModellerTests.m
+++ b/MendeleyKit/MendeleyKitTests/MendeleyDatasetModellerTests.m
@@ -228,6 +228,20 @@
     dataset.objectDescription = @"Test Desc";
     dataset.files = @[fileMetadata];
 
+    MendeleyCategory *category = [[MendeleyCategory alloc] init];
+    category.object_ID = @"#cat#";
+    dataset.categories = @[category];
+
+    MendeleyRelatedLink *link = [[MendeleyRelatedLink alloc] init];
+    link.rel = @"source_of";
+    link.type = @"other";
+    link.href = @"https://www.mendeley.com";
+    dataset.related_links = @[link];
+
+    MendeleyLicenceInfo *licenceInfo = [[MendeleyLicenceInfo alloc] init];
+    licenceInfo.object_ID = @"#lic#";
+    dataset.data_licence = licenceInfo;
+
     MendeleyModeller *modeller = [MendeleyModeller sharedInstance];
     NSError *error = nil;
     NSDictionary *datasetDictionary = [modeller dictionaryFromModel:dataset error:&error];
@@ -240,6 +254,15 @@
 
     NSArray *expectedFiles = @[@{@"filename": @"test.pdf", kMendeleyJSONContentDetails: @{kMendeleyJSONID: @"#123#"}}];
     XCTAssertEqualObjects(datasetDictionary[kMendeleyJSONFiles], expectedFiles);
+
+    NSArray *expectedCategories = @[@{kMendeleyJSONID: @"#cat#"}];
+    XCTAssertEqualObjects(datasetDictionary[kMendeleyJSONCategories], expectedCategories);
+
+    NSArray *expectedLinks = @[@{kMendeleyJSONRelatedLinksRel: @"source_of", kMendeleyJSONRelatedLinksType: @"other", kMendeleyJSONRelatedLinksHref: @"https://www.mendeley.com"}];
+    XCTAssertEqualObjects(datasetDictionary[kMendeleyJSONRelatedLinks], expectedLinks);
+
+    NSDictionary *expectedLicenceInfo = @{kMendeleyJSONID: @"#lic#"};
+    XCTAssertEqualObjects(datasetDictionary[kMendeleyJSONDataLicence], expectedLicenceInfo);
 }
 
 @end


### PR DESCRIPTION
Update modeller to serialise additional dataset properties with custom model classes:

- `categories` (array of `MendeleyCategory`)
- `related_links` (array of `MendeleyRelatedLink`)
- `data_licence` (`MendeleyLicenceInfo`)

These properties are optional when creating a new dataset.