### PR TITLE
Fix macOS deployment target (10.9) in podspec

### DIFF
--- a/MendeleyKitOSX.podspec
+++ b/MendeleyKitOSX.podspec
@@ -20,7 +20,7 @@ DESC
   s.requires_arc      = true
   s.source            = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "2.2.0" }
   s.module_name       = "MendeleyKitOSX"
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.9'
   s.source_files      = "MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h", "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.frameworks        = 'Foundation', 'CoreFoundation', 'AppKit', 'Security', 'WebKit', 'CoreServices'
   s.osx.exclude_files     = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'


### PR DESCRIPTION
Fix the macOS deployment target in podspec for CocoaPods (fix to `10.9`, was `10.10`).

For reference, both the [README](https://github.com/Mendeley/mendeleykit/blob/master/README.md#minimum-requirements) and MendeleyKit.xcodeproj configuration already define `10.9` as the macOS deployment target.

https://github.com/Mendeley/mendeleykit/blob/5c4dc740513286f11a5e05dda9d21e275d2c4f8b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj#L2366