### PR TITLE
Fix warnings

### DIFF
--- a/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
@@ -539,7 +539,6 @@
 		0B387EE919ED59C500ACCBE1 /* MendeleyCancellableRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MendeleyCancellableRequest.h; path = "Networking/NSURLConnection Provider/MendeleyCancellableRequest.h"; sourceTree = "<group>"; };
 		0B387EEC19ED695000ACCBE1 /* MendeleyNSURLRequestUploadHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MendeleyNSURLRequestUploadHelper.h; path = "Networking/NSURLConnection Provider/MendeleyNSURLRequestUploadHelper.h"; sourceTree = "<group>"; };
 		0B387EED19ED695000ACCBE1 /* MendeleyNSURLRequestUploadHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MendeleyNSURLRequestUploadHelper.m; path = "Networking/NSURLConnection Provider/MendeleyNSURLRequestUploadHelper.m"; sourceTree = "<group>"; };
-		0F7FE6F8D2A0E0F2771226C7 /* Pods-MendeleyKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		366BF49819F94E01DE1C36DE /* libPods-MendeleyKitOSXTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MendeleyKitOSXTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		373AA4EA1B4698F800F8B0C4 /* followRequest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = followRequest.json; sourceTree = "<group>"; };
 		373AA4EC1B46AAB500F8B0C4 /* followAcceptance.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = followAcceptance.json; sourceTree = "<group>"; };
@@ -583,7 +582,6 @@
 		725CFFE21B7B4D1500AC6758 /* MendeleyApplicationFeaturesAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MendeleyApplicationFeaturesAPI.m; path = "Public Interface/API Interfaces/MendeleyApplicationFeaturesAPI.m"; sourceTree = "<group>"; };
 		72D033421D647BDA004E7D1A /* MendeleyOAuthStoreProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MendeleyOAuthStoreProvider.h; path = Networking/MendeleyOAuthStoreProvider.h; sourceTree = "<group>"; };
 		732F0A391959A588D5BAFFCB /* Pods-MendeleyKitOSXTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitOSXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests.debug.xcconfig"; sourceTree = "<group>"; };
-		8302971636AF25A993EDBA94 /* Pods-MendeleyKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitTests/Pods-MendeleyKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9DEA9B99D5FE40BEB2C9E99F /* libPods-MendeleyKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MendeleyKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A304643800733756F1157F04 /* Pods-MendeleyKitOSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MendeleyKitOSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests.release.xcconfig"; sourceTree = "<group>"; };
 		C406B3011B611862003040F5 /* MendeleyDefaultAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MendeleyDefaultAnalytics.swift; path = Analytics/MendeleyDefaultAnalytics.swift; sourceTree = "<group>"; };
@@ -898,8 +896,6 @@
 		BC8B75FE7E591BB0E3D3CA78 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8302971636AF25A993EDBA94 /* Pods-MendeleyKitTests.debug.xcconfig */,
-				0F7FE6F8D2A0E0F2771226C7 /* Pods-MendeleyKitTests.release.xcconfig */,
 				DFDCE2E92DC2090614D79B17 /* Pods-MendeleyKitiOSTests.debug.xcconfig */,
 				F121F55BE4CD06F6F3C91312 /* Pods-MendeleyKitiOSTests.release.xcconfig */,
 				732F0A391959A588D5BAFFCB /* Pods-MendeleyKitOSXTests.debug.xcconfig */,

--- a/MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h
+++ b/MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h
@@ -106,3 +106,10 @@ FOUNDATION_EXPORT const unsigned char MendeleyKitOSXVersionString[];
 #import <MendeleyKitOSX/MendeleyNSURLConnectionProvider.h>
 #import <MendeleyKitOSX/MendeleyAnalyticsRegistry.h>
 #import <MendeleyKitOSX/MendeleyDatasetsAPI.h>
+#import <MendeleyKitOSX/MendeleyApplicationFeaturesAPI.h>
+#import <MendeleyKitOSX/MendeleyCommentsAPI.h>
+#import <MendeleyKitOSX/MendeleyFeedsAPI.h>
+#import <MendeleyKitOSX/MendeleyKit-Umbrella.h>
+#import <MendeleyKitOSX/MendeleyPhotosMeAPI.h>
+#import <MendeleyKitOSX/MendeleySharesAPI.h>
+#import <MendeleyKitOSX/MendeleyUserPostsAPI.h>

--- a/MendeleyKit/MendeleyKitiOS/MendeleyKitiOS.h
+++ b/MendeleyKit/MendeleyKitiOS/MendeleyKitiOS.h
@@ -105,4 +105,11 @@ FOUNDATION_EXPORT const unsigned char MendeleyKitiOSVersionString[];
 #import <MendeleyKitiOS/MendeleyAnalyticsRegistry.h>
 #import <MendeleyKitiOS/MendeleyFeature.h>
 #import <MendeleyKitiOS/MendeleyDatasetsAPI.h>
-
+#import <MendeleyKitiOS/MendeleyApplicationFeaturesAPI.h>
+#import <MendeleyKitiOS/MendeleyCommentsAPI.h>
+#import <MendeleyKitiOS/MendeleyFeedsAPI.h>
+#import <MendeleyKitiOS/MendeleyKit-Umbrella.h>
+#import <MendeleyKitiOS/MendeleyPhotosMeAPI.h>
+#import <MendeleyKitiOS/MendeleyRecommendationsAPI.h>
+#import <MendeleyKitiOS/MendeleySharesAPI.h>
+#import <MendeleyKitiOS/MendeleyUserPostsAPI.h>


### PR DESCRIPTION
- Fix missing CocoaPods configuration files (referencing old files that no longer exist, now that the Podfile is split between iOS and macOS)
- Fix missing header files in umbrella header (“Umbrella header for module 'MendeleyKitiOS' does not include header '...'”)

