### PR TITLE
Fix warnings

### DIFF
--- a/MendeleyKit/MendeleyKit/Analytics/MendeleyDefaultAnalytics.swift
+++ b/MendeleyKit/MendeleyKit/Analytics/MendeleyDefaultAnalytics.swift
@@ -66,7 +66,7 @@ open class MendeleyDefaultAnalytics: NSObject, MendeleyAnalytics
     
     open func logMendeleyAnalyticsEvents(_ events:[MendeleyAnalyticsEvent])
     {
-        if versionString.characters.count == 0 || profileUUID.characters.count == 0
+        if versionString.count == 0 || profileUUID.count == 0
         {
             return
         }

--- a/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestDownloadHelper.m
+++ b/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestDownloadHelper.m
@@ -22,8 +22,6 @@
 #import "MendeleyErrorManager.h"
 #import "MendeleyError.h"
 
-#define NSURLResponseUnknownLength ((long long) -1)
-
 
 @interface MendeleyNSURLRequestDownloadHelper ()
 @property (nonatomic, strong) NSURL *fileURL;

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyQueryRequestParameters.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyQueryRequestParameters.h
@@ -129,7 +129,6 @@
 
 @interface MendeleyFeedsParameters : MendeleyQueryRequestParameters
 @property (nonatomic, strong) NSString *profile_id;
-@property (nonatomic, strong) NSString *group_id;
 @property (nonatomic, strong) NSString *cut_off;
 @end
 


### PR DESCRIPTION
Fix compilation warnings:

- redefined macro (already defined in Foundation)
- redefined property (already defined in superclass)
- deprecated Swift code for String manipulation

<img width="398" alt="screen shot 2018-01-16 at 10 15 52" src="https://user-images.githubusercontent.com/886053/34981513-faafac36-faa7-11e7-9264-90380c5609f3.png">
<img width="404" alt="screen shot 2018-01-16 at 10 16 37" src="https://user-images.githubusercontent.com/886053/34981520-feb36d2c-faa7-11e7-8683-bb02c2c1aa00.png">
<img width="381" alt="screen shot 2018-01-16 at 10 23 58" src="https://user-images.githubusercontent.com/886053/34981527-0147cd58-faa8-11e7-96ef-a8a74f772694.png">