### PR TITLE
Define Swift version in podspec (new CocoaPods attribute)

### DIFF
--- a/MendeleyKitOSX.podspec
+++ b/MendeleyKitOSX.podspec
@@ -24,4 +24,5 @@ DESC
   s.source_files      = "MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h", "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.frameworks        = 'Foundation', 'CoreFoundation', 'AppKit', 'Security', 'WebKit', 'CoreServices'
   s.osx.exclude_files     = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'
+  s.swift_version = '3.2'
 end

--- a/MendeleyKitiOS.podspec
+++ b/MendeleyKitiOS.podspec
@@ -22,4 +22,5 @@ DESC
   s.module_name = "MendeleyKitiOS"
   s.ios.deployment_target = '8.0'
   s.source_files  = "MendeleyKit/MendeleyKitiOS/MendeleyKitiOS.h", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
+  s.swift_version = '3.2'
 end


### PR DESCRIPTION
Define the pod Swift version in podspec, with new CocoaPods attribute.

Documentation: https://guides.cocoapods.org/syntax/podspec.html#swift_version