### PR TITLE
Add new podspec file for cross-platform static libraries

### DIFF
--- a/MendeleyKit.podspec
+++ b/MendeleyKit.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name = "MendeleyKit"
+  s.version = "3.3.0"
+  s.summary = "The Mendeley Objective-C/Swift client SDK."
+  s.description = <<-DESC
+                  # MendeleyKit
+                  The open source Mendeley Objective-C/Swift Kit.
+
+                  ## Features
+                  * Access to Mendeley REST API endpoints and handling of JSON responses
+                  * Provide model classes for essential Mendeley objects such as Mendeley documents
+                  * OAuth2 authentication and login as well as automatic handling of access refresh
+DESC
+  s.homepage = "https://github.com/Mendeley/mendeleykit"
+  s.license = 'Apache Licence, Version 2.0'
+  s.authors = { "Mendeley iOS" => "ios@mendeley.com"}
+
+  s.source = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.3.0" }
+  s.module_name  = "MendeleyKit"
+  s.swift_version = '3.2'
+  s.requires_arc = true
+
+  s.ios.deployment_target = '8.0'
+  s.ios.source_files = "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
+
+  s.macos.deployment_target = '10.9'
+  s.macos.source_files = "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
+  s.macos.exclude_files = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'
+end

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit-Umbrella.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit-Umbrella.h
@@ -26,4 +26,8 @@
 #import <MendeleyKitOSX/MendeleyKitOSX-Swift.h>
 #endif
 
+#if __has_include("MendeleyKit-Swift.h")
+#import "MendeleyKit-Swift.h"
+#endif
+
 #include "MendeleyKit.h"

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.m
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.m
@@ -25,6 +25,7 @@
 #import "MendeleyOAuthStore.h"
 #import "MendeleyDefaultOAuthProvider.h"
 #import "NSError+MendeleyError.h"
+#import "MendeleyObject.h"
 #import "MendeleyKit-Umbrella.h"
 
 @interface MendeleyLoginViewController ()

--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ Much of the code in the SDK is still based on Objective C. However, over the com
 towards Swift (3 or later).
 
 ## Minimum Requirements ##
-
-Xcode 8
-iOS 8.0 or higher
-OS X 10.9 or higher
+- Xcode 8
+- iOS 8.0 or higher
+- macOS 10.9 or higher
 
 ## Installation (CocoaPods) ##
-The easiest way to include MendeleyKit in your project is to use CocoaPods. In order to support both
-dynamic frameworks for both macOS and macOS we provide two separate Podspec files
-- `MendeleyKitiOS.podspec`: the macOS dynamic framework. Requires iOS 9.1 min and Xcode 8.x
-- `MendeleyKitOSX.podspec`: the OS X framework.
+The easiest way to include MendeleyKit in your project is to use CocoaPods. There are 3 pods: one is cross-platform and can be used as a static library; the others are platform-specific and can be used as dynamic frameworks:
+- `MendeleyKit.podspec`: iOS/macOS static framework
+- `MendeleyKitiOS.podspec`: iOS dynamic framework
+- `MendeleyKitOSX.podspec`: macOS dynamic framework
 
 ### CocoaPods for frameworks ###
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ towards Swift (3 or later).
 
 ## Installation (CocoaPods) ##
 The easiest way to include MendeleyKit in your project is to use CocoaPods. There are 3 pods: one is cross-platform and can be used as a static library; the others are platform-specific and can be used as dynamic frameworks:
-- `MendeleyKit.podspec`: iOS/macOS static framework
+- `MendeleyKit.podspec`: iOS/macOS static library (requires Xcode 9 and CocoaPods 1.5)
 - `MendeleyKitiOS.podspec`: iOS dynamic framework
 - `MendeleyKitOSX.podspec`: macOS dynamic framework
 


### PR DESCRIPTION
The new podspec (`MendeleyKit.podspec`) combines the 2 existing podspec files. It adds support for static libraries (no need for `use_frameworks!` in the Podfile) for projects on both platforms (iOS and macOS).

- Update `MendeleyKit-Umbrella.h` to import the new Swift auto-generated header when necessary
- Update `MendeleyLoginViewController.m` to avoid forward definition from `MendeleyObject.h` (not sure why it is different for static libraries)
- Update `README.md` to list the 3 podspec files

This new podspec file minimises the changes required to support cross-platform projects and static libraries, and should not impact the existing podspec files.

More info about CocoaPods and static libraries: [CocoaPods 1.5.0 — Swift Static Libraries](http://blog.cocoapods.org/CocoaPods-1.5.0/)