### PR TITLE
Fix macOS login window controller support for new authentication method

### DIFF
--- a/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.m
+++ b/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.m
@@ -26,7 +26,8 @@
 #import "MendeleyDefaultOAuthProvider.h"
 #import "NSError+MendeleyError.h"
 
-@interface MendeleyLoginWindowController ()
+@interface MendeleyLoginWindowController () <WebPolicyDelegate, WebFrameLoadDelegate>
+
 @property (nonatomic, strong) WebView *webView;
 @property (nonatomic, strong) NSURL *oauthServer;
 @property (nonatomic, strong) NSString *clientID;
@@ -125,25 +126,15 @@
                               frame:(WebFrame *)frame
                    decisionListener:(id<WebPolicyDecisionListener>)listener
 {
-    if ([request.URL.absoluteString hasPrefix:[self.oauthServer absoluteString]])
-    {
-        [listener use];
-        return;
-    }
-
     NSString *code = [self authenticationCodeFromURLRequest:request];
     if (nil != code)
     {
         MendeleyOAuthCompletionBlock oAuthCompletionBlock = self.oAuthCompletionBlock;
         [self.oauthProvider authenticateWithAuthenticationCode:code
                                                completionBlock:oAuthCompletionBlock];
-        [listener ignore];
-        return;
     }
 
-    ///TODO error handling
-
-    [listener ignore];
+    [listener use];
 }
 
 - (void)         webView:(WebView *)sender
@@ -165,9 +156,6 @@
     {
         completionBlock(NO, error);
     }
-    self.oAuthCompletionBlock = nil;
-    self.completionBlock = nil;
-    self.webView = nil;
 }
 
 #pragma mark private methods


### PR DESCRIPTION
The new Mendeley API authentication method (“Elsevier login”, mandatory starting November 1st, 2019) requires the login web view to support multiple redirections, including different domains.

This pull request updates the macOS login window controller to support this new authentication flow, while keeping backward compatibility with the legacy login method.