### PR TITLE
Update clean web cache method with new WebKit API

### DIFF
--- a/MendeleyKit.podspec
+++ b/MendeleyKit.podspec
@@ -20,10 +20,10 @@ DESC
   s.swift_version = '5.0'
   s.requires_arc = true
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
   s.ios.source_files = "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
 
-  s.macos.deployment_target = '10.9'
+  s.macos.deployment_target = '10.10'
   s.macos.source_files = "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.macos.exclude_files = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'
 end

--- a/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKit.xcodeproj/project.pbxproj
@@ -1748,8 +1748,6 @@
 				C46656511B3842B0005F762A /* Sources */,
 				C46656521B3842B0005F762A /* Frameworks */,
 				C46656531B3842B0005F762A /* Resources */,
-				120B78C20A86AED3C30CDD32 /* [CP] Copy Pods Resources */,
-				09939FE7E1FAD2813F6C0730 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1769,8 +1767,6 @@
 				D7A3C0DB1D4BAE5300CF12A9 /* Sources */,
 				D7A3C0DC1D4BAE5300CF12A9 /* Frameworks */,
 				D7A3C0DD1D4BAE5300CF12A9 /* Resources */,
-				77FB8AEE4B79C0F05257C49A /* [CP] Embed Pods Frameworks */,
-				7964046578F4525B70AC0973 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1909,79 +1905,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09939FE7E1FAD2813F6C0730 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		120B78C20A86AED3C30CDD32 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitiOSTests/Pods-MendeleyKitiOSTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		77FB8AEE4B79C0F05257C49A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7964046578F4525B70AC0973 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MendeleyKitOSXTests/Pods-MendeleyKitOSXTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		83186CA70A068E44C8081906 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MendeleyKitOSXTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FEE64BBFF23189E9C8F16241 /* [CP] Check Pods Manifest.lock */ = {
@@ -1990,13 +1929,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MendeleyKitiOSTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2338,7 +2280,7 @@
 				INFOPLIST_FILE = MendeleyKitOSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MARKETING_VERSION = 3.4.3;
 				MODULEMAP_FILE = "MendeleyKit-OSX.modulemap";
 				MODULE_NAME = com.mendeley.MendeleyKit;
@@ -2376,7 +2318,7 @@
 				INFOPLIST_FILE = MendeleyKitOSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MARKETING_VERSION = 3.4.3;
 				MODULEMAP_FILE = "MendeleyKit-OSX.modulemap";
 				MODULE_NAME = com.mendeley.MendeleyKit;
@@ -2414,14 +2356,9 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREFIX_HEADER = "";
-				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = (
-					"DEBUG=1",
-					"$(inherited)",
-					MendeleyKitiOSFramework,
-				);
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "DEBUG=1 $(inherited) MendeleyKitiOSFramework";
 				INFOPLIST_FILE = MendeleyKitiOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 3.4.3;
 				MODULEMAP_FILE = "MendeleyKit-iOS.modulemap";
@@ -2465,7 +2402,6 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = MendeleyKitiOSFramework;
 				INFOPLIST_FILE = MendeleyKitiOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 3.4.3;
 				MODULEMAP_FILE = "MendeleyKit-iOS.modulemap";
@@ -2499,7 +2435,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "MendeleyKit/MendeleyKit-Prefix.pch";
 				INFOPLIST_FILE = MendeleyKitiOSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitiOSTests;
@@ -2524,7 +2459,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "MendeleyKit/MendeleyKit-Prefix.pch";
 				INFOPLIST_FILE = MendeleyKitiOSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitiOSTests;
@@ -2581,7 +2515,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
@@ -2628,7 +2563,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -2650,7 +2586,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = MendeleyKitOSXTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitOSXTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2673,7 +2608,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = MendeleyKitOSXTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mendeley.MendeleyKitOSXTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSX.xcscheme
+++ b/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "145C2DB11A2CA84A0005BFF6"
+            BuildableName = "MendeleyKitOSXExample.app"
+            BlueprintName = "MendeleyKitOSXExample"
+            ReferencedContainer = "container:MendeleyKitExample/MendeleyKitExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "145C2DB11A2CA84A0005BFF6"
-            BuildableName = "MendeleyKitOSXExample.app"
-            BlueprintName = "MendeleyKitOSXExample"
-            ReferencedContainer = "container:MendeleyKitExample/MendeleyKitExample.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:MendeleyKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitiOS.xcscheme
+++ b/MendeleyKit/MendeleyKit.xcodeproj/xcshareddata/xcschemes/MendeleyKitiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C466564B1B3842AF005F762A"
+            BuildableName = "MendeleyKitiOS.framework"
+            BlueprintName = "MendeleyKitiOS"
+            ReferencedContainer = "container:MendeleyKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C466564B1B3842AF005F762A"
-            BuildableName = "MendeleyKitiOS.framework"
-            BlueprintName = "MendeleyKitiOS"
-            ReferencedContainer = "container:MendeleyKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:MendeleyKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.m
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.m
@@ -49,7 +49,7 @@
 #import "MendeleySharesAPI.h"
 #import "MendeleyUserPostsAPI.h"
 #import "MendeleyCommentsAPI.h"
-
+#import "MendeleyKit-Umbrella.h"
 
 @interface MendeleyKit ()
 
@@ -213,6 +213,9 @@
 - (void)clearAuthentication
 {
     [MendeleyKitConfiguration.sharedInstance.storeProvider removeOAuthCredentials];
+#if TARGET_OS_IPHONE
+    [MendeleyKitLoginHelper cleanCookiesAndURLCache];
+#endif
 }
 
 - (MendeleyTask *)checkAuthorisationStatusWithCompletionBlock:(MendeleyCompletionBlock)completionBlock

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
@@ -71,9 +71,4 @@ open class MendeleyKitLoginHelper: NSObject
             dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: records.filter { $0.displayName.contains("mendeley.com") }) {}
         }
     }
-
-    open func cleanCookiesAndURLCache()
-    {
-        MendeleyKitLoginHelper.cleanCookiesAndURLCache()
-    }
 }

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyKitLoginHelper.swift
@@ -66,31 +66,9 @@ open class MendeleyKitLoginHelper: NSObject
     @objc
     public static func cleanCookiesAndURLCache()
     {
-        if #available(iOS 9.0, *)
-        {
-            let dataStore = WKWebsiteDataStore.default()
-            dataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-                dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: records.filter { $0.displayName.contains("mendeley.com") }) {}
-            }
-        }
-        else
-        {
-            let oauthServer = MendeleyKitConfiguration.sharedInstance().baseAPIURL
-            URLCache.shared.removeAllCachedResponses()
-
-            let cookieStorage = HTTPCookieStorage.shared
-
-            guard let cookies = cookieStorage.cookies as [HTTPCookie]?
-                else { return }
-
-            for cookie in cookies
-            {
-                let domain = cookie.domain
-                if domain == kMendeleyKitURL || domain == oauthServer?.host
-                {
-                    cookieStorage.deleteCookie(cookie)
-                }
-            }
+        let dataStore = WKWebsiteDataStore.default()
+        dataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+            dataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: records.filter { $0.displayName.contains("mendeley.com") }) {}
         }
     }
 

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginWebKitHandler.swift
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginWebKitHandler.swift
@@ -21,7 +21,6 @@
 import UIKit
 import WebKit
 
-@available (iOS 9.0, *)
 public class MendeleyLoginWebKitHandler: NSObject, WKNavigationDelegate, WKUIDelegate, MendeleyLoginHandler
 {
     let oAuthServer: URL = MendeleyKitConfiguration.sharedInstance().baseAPIURL

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginWebKitHandler.swift
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginWebKitHandler.swift
@@ -37,7 +37,6 @@ public class MendeleyLoginWebKitHandler: NSObject, WKNavigationDelegate, WKUIDel
         configureWebView(controller)
 
         let helper = MendeleyKitLoginHelper()
-        helper.cleanCookiesAndURLCache()
         let request: URLRequest = helper.getOAuthRequest(redirectURI, clientID: clientID)
         _ = webView?.load(request)
     }

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/project.pbxproj
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 		C4A1346619DADB010069DB7A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = Mendeley;
 				TargetAttributes = {
 					145C2DB11A2CA84A0005BFF6 = {
@@ -260,7 +260,7 @@
 			};
 			buildConfigurationList = C4A1346919DADB010069DB7A /* Build configuration list for PBXProject "MendeleyKitExample" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -388,7 +388,7 @@
 				INFOPLIST_FILE = MendeleyKitOSXExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -415,7 +415,7 @@
 				INFOPLIST_FILE = MendeleyKitOSXExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mendeley.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -427,6 +427,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -469,7 +470,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -479,6 +481,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -514,7 +517,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitExample.xcscheme
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSXExample.xcscheme
+++ b/MendeleyKit/MendeleyKitExample/MendeleyKitExample.xcodeproj/xcshareddata/xcschemes/MendeleyKitOSXExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:MendeleyKitExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MendeleyKit/Podfile
+++ b/MendeleyKit/Podfile
@@ -1,12 +1,11 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-
 target :MendeleyKitiOSTests do
-	platform :ios, '9.0'
+	platform :ios, '11.0'
     pod 'OCMock'
 end
 
 target :MendeleyKitOSXTests do
-	platform :osx, '10.9'
+	platform :osx, '10.10'
     pod 'OCMock'
 end

--- a/MendeleyKitOSX.podspec
+++ b/MendeleyKitOSX.podspec
@@ -20,7 +20,7 @@ DESC
   s.requires_arc      = true
   s.source            = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.4.3" }
   s.module_name       = "MendeleyKitOSX"
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '10.10'
   s.source_files      = "MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h", "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.frameworks        = 'Foundation', 'CoreFoundation', 'AppKit', 'Security', 'WebKit', 'CoreServices'
   s.osx.exclude_files     = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'

--- a/MendeleyKitiOS.podspec
+++ b/MendeleyKitiOS.podspec
@@ -20,7 +20,7 @@ DESC
   s.requires_arc  = true
   s.source       = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.4.3" }
   s.module_name = "MendeleyKitiOS"
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
   s.source_files  = "MendeleyKit/MendeleyKitiOS/MendeleyKitiOS.h", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.swift_version = '5.0'
 end

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Much of the code in the SDK is still based on Objective-C. However, over the com
 
 ## Minimum requirements ##
 - Xcode 8
-- iOS 8.0 or higher
-- macOS 10.9 or higher
+- iOS 11.0 or higher
+- macOS 10.10 or higher
 
 ## Installation (CocoaPods) ##
 The easiest way to include MendeleyKit in your project is to use CocoaPods. There are 3 pods: one is cross-platform and can be used as a static library; the others are platform-specific and can be used as dynamic frameworks:


### PR DESCRIPTION
- Update clean web cache method with new WebKit API
- Clean web cache at signout instead of before presenting the login view, because the new method is asynchronous
- Update library requirements to iOS 11 and macOS 10.10