### PR TITLE
Fix analytics events serialization

### DIFF
--- a/MendeleyKit/MendeleyKit/Analytics/MendeleyAnalyticsCacheManager.swift
+++ b/MendeleyKit/MendeleyKit/Analytics/MendeleyAnalyticsCacheManager.swift
@@ -78,7 +78,14 @@ open class MendeleyAnalyticsCacheManager: NSObject
     
     open func sendAndClearAnalyticsEvents(_ completionHandler: MendeleyCompletionBlock?)
     {
-        let events = eventsFromArchive()
+        // Need to filter out events with no name or no origin identity/version
+        // The API now rejects requests without those values,
+        // and the previous version of this library would not serialize them properly,
+        // hence accumulating invalid events in the cache.
+        let events = eventsFromArchive().filter {
+            $0.name != nil && $0.origin[kMendeleyAnalyticsJSONOriginIdentity] != nil && $0.origin[kMendeleyAnalyticsJSONOriginVersion] != nil
+        }
+
         if 0 == events.count
         {
             if nil != completionHandler

--- a/MendeleyKit/MendeleyKit/Analytics/MendeleyAnalyticsEvent.swift
+++ b/MendeleyKit/MendeleyKit/Analytics/MendeleyAnalyticsEvent.swift
@@ -20,16 +20,16 @@
 
 import Foundation
 
-open class MendeleyAnalyticsEvent: MendeleySecureObject
+@objc open class MendeleyAnalyticsEvent: MendeleySecureObject
 {
-    open var name:String!
-    open var timestamp = Date()
-    open var profileID: String!
-    open var session_ID: String!
-    open var profile_uuid: String!
-    open var origin = [kMendeleyAnalyticsJSONOriginOS : kOriginOS,
+    @objc open var name:String!
+    @objc open var timestamp = Date()
+    @objc open var profileID: String!
+    @objc open var session_ID: String!
+    @objc open var profile_uuid: String!
+    @objc open var origin = [kMendeleyAnalyticsJSONOriginOS : kOriginOS,
         kMendeleyAnalyticsJSONOriginType: kOriginType]
-    public var properties = [String:Any]()
+    @objc public var properties = [String:Any]()
     
     public var duration_milliseconds: Int? {
         get {

--- a/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
+++ b/MendeleyKit/MendeleyKitTests/MendeleyAnalyticsTests.swift
@@ -122,4 +122,25 @@ class MendeleyAnalyticsTests: XCTestCase {
         let cachedEvents = manager.eventsFromArchive()
         XCTAssertTrue(20 == cachedEvents.count, "We should have 20 events but got \(cachedEvents.count)")
     }
+
+    func testEventSerialization() throws
+    {
+        let event = MendeleyAnalyticsEvent(name: "MyEvent")
+        let modeller = MendeleyModeller.sharedInstance()
+        let data = try modeller.jsonObject(fromModelOrModels: [event]) as Data
+        XCTAssertNotNil(data)
+
+        let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+        let jsonArray = try XCTUnwrap(jsonObject as? Array<Dictionary<String, Any>>)
+        XCTAssertEqual(jsonArray.count, 1)
+
+        let jsonEvent = try XCTUnwrap(jsonArray[0])
+        XCTAssertEqual(jsonEvent["name"] as? String, "MyEvent")
+        XCTAssertEqual(jsonEvent["properties"] as? Dictionary<String, String>, [:])
+        XCTAssertNotNil(jsonEvent["timestamp"] as? String)
+
+        let jsonOrigin = try XCTUnwrap(jsonEvent["origin"] as? Dictionary<String, String>)
+        XCTAssertEqual(jsonOrigin["os"], "iOS")
+        XCTAssertEqual(jsonOrigin["type"], "IOS")
+    }
 }


### PR DESCRIPTION
This might be a bug that appeared when we upgraded to a more modern version of Swift. The object properties have to be declared with `@objc` to be exposed to `MendeleyModeller` for serialization.

Consequently, it addresses the issue with the server requiring analytics events name and origin (with identity and version). But to be complete, we need to ignore events cached with a previous version of this library, otherwise the “send analytics” method would keep on failing with the old events missing the required properties.