### PR TITLE
Update credentials storage with secure coding

### DIFF
--- a/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthCredentials.m
+++ b/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthCredentials.m
@@ -58,15 +58,11 @@
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
-    NSArray *propertyNames = [MendeleyObjectHelper propertyNamesForModel:self];
-
-    [propertyNames enumerateObjectsUsingBlock:^(NSString *name, NSUInteger idx, BOOL *stop) {
-         id value = [self valueForKey:name];
-         if (nil != value)
-         {
-             [encoder encodeObject:value forKey:name];
-         }
-     }];
+    [encoder encodeObject:self.refresh_token forKey:NSStringFromSelector(@selector(refresh_token))];
+    [encoder encodeObject:self.currentDate forKey:NSStringFromSelector(@selector(currentDate))];
+    [encoder encodeObject:self.token_type forKey:NSStringFromSelector(@selector(token_type))];
+    [encoder encodeObject:self.access_token forKey:NSStringFromSelector(@selector(access_token))];
+    [encoder encodeObject:self.expires_in forKey:NSStringFromSelector(@selector(expires_in))];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder
@@ -84,15 +80,11 @@
 
 - (void)decodeWithDecoder:(NSCoder *)decoder
 {
-    NSArray *propertyNames = [MendeleyObjectHelper propertyNamesForModel:self];
-
-    [propertyNames enumerateObjectsUsingBlock:^(NSString *name, NSUInteger idx, BOOL *stop) {
-         id value = [decoder decodeObjectOfClass:[self class] forKey:name];
-         if (nil != value)
-         {
-             [self setValue:value forKey:name];
-         }
-     }];
+    self.refresh_token = [decoder decodeObjectOfClass:NSString.class forKey:NSStringFromSelector(@selector(refresh_token))];
+    self.currentDate = [decoder decodeObjectOfClass:NSDate.class forKey:NSStringFromSelector(@selector(currentDate))];
+    self.token_type = [decoder decodeObjectOfClass:NSString.class forKey:NSStringFromSelector(@selector(token_type))];
+    self.access_token = [decoder decodeObjectOfClass:NSString.class forKey:NSStringFromSelector(@selector(access_token))];
+    self.expires_in = [decoder decodeObjectOfClass:NSNumber.class forKey:NSStringFromSelector(@selector(expires_in))];
 }
 
 @end

--- a/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthStore.m
+++ b/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthStore.m
@@ -57,7 +57,7 @@ static NSMutableDictionary * keychainQueryDictionaryWithIdentifier()
     }
     NSMutableDictionary *keychainDictionary = keychainQueryDictionaryWithIdentifier();
     NSMutableDictionary *updateDictionary = [NSMutableDictionary dictionary];
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:credentials];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:credentials requiringSecureCoding:YES error:nil];
     [updateDictionary setObject:data forKey:(__bridge id) kSecValueData];
     [updateDictionary setObject:(__bridge id) kSecAttrAccessibleWhenUnlocked
                          forKey:(__bridge id) kSecAttrAccessible];
@@ -114,11 +114,8 @@ static NSMutableDictionary * keychainQueryDictionaryWithIdentifier()
     }
 
     NSData *data = (__bridge NSData *) result;
-    MendeleyOAuthCredentials *oauthData = (MendeleyOAuthCredentials *) [NSKeyedUnarchiver unarchiveObjectWithData:data];
-    if (nil == oauthData)
-    {
-    }
+    MendeleyOAuthCredentials *oauthData = (MendeleyOAuthCredentials *) [NSKeyedUnarchiver unarchivedObjectOfClass:MendeleyOAuthCredentials.class fromData:data error:nil];
     return oauthData;
-
 }
+
 @end


### PR DESCRIPTION
Update `MendeleyOAuthCredentials` storage to support secure coding, as iOS 14 now logs a warning when using non-secured keyed archive:

> 'NSKeyedUnarchiveFromData' should not be used to for un-archiving and will be removed in a future release

This previous implementation was not compliant with secure coding because the following line was expecting the wrong class for the object properties.

```
id value = [decoder decodeObjectOfClass:[self class] forKey:name];
```