### PR TITLE
Fix warnings

### DIFF
--- a/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.h
+++ b/MendeleyKit/MendeleyKit/Model/Mendeley Objects/MendeleyAnnotation.h
@@ -51,17 +51,11 @@
    Annotations have color components, which are stored as map<string, integer>, where string is
    either r,g,b
    This method converts the color JSON map into a UIColor object (iOS) or NSColor object (Mac OSX)
-   @param colorParameters
-   @param error
-   @return a UIColor/NSColor object or nil if error
  */
 + (id)colorFromParameters:(NSDictionary *)colorParameters error:(NSError **)error;
 
 /**
-   converts a color object (UIColor/NSColor) back into JSON
-   @param color
-   @param error
-   @return JSON map of color components
+   converts a color object (UIColor/NSColor) back into JSON map of color components
  */
 + (NSDictionary *)jsonColorFromColor:(id)color error:(NSError **)error;
 @end
@@ -74,17 +68,11 @@
 /**
    Annotations store position details as a map with parameters such as top_left etc.
    This converts a JSON map containing position metadata into a MendeleyHighlightBox object
-   @param boxParameters
-   @param error
-   @return a highlight box object
  */
 + (MendeleyHighlightBox *)boxFromJSONParameters:(NSDictionary *)boxParameters error:(NSError **)error;
 
 /**
    converts a highlight box object back into a NSDictionary (JSON map)
-   @param box
-   @param error
-   @return a map to be used in JSON
  */
 + (NSDictionary *)jsonBoxFromHighlightBox:(MendeleyHighlightBox *)box error:(NSError **)error;
 @end

--- a/MendeleyKit/MendeleyKit/Model/MendeleyModeller.h
+++ b/MendeleyKit/MendeleyKit/Model/MendeleyModeller.h
@@ -30,7 +30,7 @@
 
 /**
    @param jsonData should be already deserialized JSON data, either NSArray or NSDictionary
-   @param expectedType
+   @param expectedType expected type
    @param completionBlock will return either a MendeleyObject type model class or an NSArray of model objects
  */
 - (void)parseJSONData:(nonnull id)jsonData
@@ -40,7 +40,7 @@
 /**
    converts an existing Model class into a serialized JSON object (NSData)
    @param model can either be a model object or an array of model objects
-   @param error
+   @param error error
    @return a serialized NSData JSON object or nil if error
  */
 - (nullable NSData *)jsonObjectFromModelOrModels:(nonnull id)model error:(NSError *__nullable *__nullable)error;
@@ -58,8 +58,8 @@
    {
     "id" : "xxxxx-xxxx-xxxx-xxxxxxxxx"
    }
-   @param objectID
-   @param error
+   @param objectID object ID
+   @param error error
    @return JSON object as NSData or nil if error
  */
 - (nullable NSData *)jsonObjectForID:(nonnull NSString *)objectID error:(NSError *__nullable *__nullable)error;
@@ -67,9 +67,8 @@
 /**
  *    converts an existing Model class into a serialized dictionary object (NSDictionary)
  *
- *  @param model model is a model object
+ *  @param model model object
  *  @param error error
- *
  *  @return dictionary object as NSDictionary or nil if error
  */
 - (nullable NSDictionary *)dictionaryFromModel:(nonnull id)model error:(NSError *__nullable *__nullable)error;

--- a/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDataHelper.h
+++ b/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDataHelper.h
@@ -27,21 +27,12 @@
    @name This class provides callback methods for download tasks. Used in conjunction with the
    Default Network Provider (NSURLSession based)
  */
-/**
-   @param session
-   @param dataTask
-   @param response
-   @param completionHandler
- */
 - (void)    URLSession:(NSURLSession *)session
               dataTask:(MendeleyNetworkTask *)dataTask
     didReceiveResponse:(NSURLResponse *)response
      completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler;
 
 /**
-   @param session
-   @param task
-   @param error
  */
 - (void)      URLSession:(NSURLSession *)session
                     task:(MendeleyNetworkTask *)task

--- a/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDefaultNetworkProvider.m
+++ b/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDefaultNetworkProvider.m
@@ -792,12 +792,12 @@
           didFinishDownloadingToURL:location];
 } 
 
-#warning needs implementing
 - (void)    URLSession:(NSURLSession *)session
           downloadTask:(NSURLSessionDownloadTask *)downloadTask
      didResumeAtOffset:(int64_t)fileOffset
     expectedTotalBytes:(int64_t)expectedTotalBytes
 {
+    // needs implementing
 }
 
 - (void)            URLSession:(NSURLSession *)session

--- a/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDownloadHelper.h
+++ b/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyDownloadHelper.h
@@ -31,11 +31,6 @@
 
 /**
    This method is used to provide progress feedback for download tasks
-   @param session
-   @param downloadTask
-   @param bytesWritten
-   @param totalBytesWritten
-   @param totalBytesExpectedToWrite
  */
 - (void)           URLSession:(NSURLSession *)session
                  downloadTask:(MendeleyNetworkDownloadTask *)downloadTask
@@ -45,9 +40,6 @@
 
 /**
    this method notifies when the download terminates
-   @param session
-   @param downloadTask
-   @param location
  */
 - (void)           URLSession:(NSURLSession *)session
                  downloadTask:(MendeleyNetworkDownloadTask *)downloadTask

--- a/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyNetworkTask.h
+++ b/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyNetworkTask.h
@@ -30,9 +30,6 @@
 
 /**
    initialises a network task
-   @param request
-   @param session
-   @param completionBlock
  */
 - (instancetype)initTaskWithRequest:(NSURLRequest *)request
                             session:(NSURLSession *)session
@@ -45,7 +42,6 @@
 
 /**
    cancels a task
-   @param completionBlock
  */
 - (void)cancelTaskWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
@@ -58,11 +54,11 @@
 @property (copy, nonatomic, readonly) MendeleyResponseProgressBlock progressBlock;
 
 /**
-   @param request
-   @param session
-   @param fileURL - location of file to be uploaded
-   @param progressBlock
-   @param completionBlock
+   @param request request
+   @param session session
+   @param fileURL location of file to be uploaded
+   @param progressBlock progress block
+   @param completionBlock completion block
  */
 - (instancetype)initUploadTaskWithRequest:(NSURLRequest *)request
                                   session:(NSURLSession *)session
@@ -82,11 +78,11 @@
 
 /**
    initialises a MendeleyNetworkDownloadTask
-   @param request
-   @param session
-   @param fileURL - download file location
-   @param progressBlock
-   @param completionBlock
+   @param request request
+   @param session session
+   @param fileURL download file location
+   @param progressBlock progress block
+   @param completionBlock completion block
  */
 - (instancetype)initDownloadTaskWithRequest:(NSURLRequest *)request
                                     session:(NSURLSession *)session
@@ -96,7 +92,6 @@
 
 /**
    Adds a NSURLSessionDownloadTask to the object for execution
-   @param downloadTask
  */
 - (void)addRealDownloadTask:(NSURLSessionDownloadTask *)downloadTask;
 

--- a/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyUploadHelper.h
+++ b/MendeleyKit/MendeleyKit/Networking/Default Network Provider/MendeleyUploadHelper.h
@@ -29,11 +29,6 @@
 @interface MendeleyUploadHelper : NSObject
 
 /**
-   @param session
-   @param uploadTask
-   @param bytesSent
-   @param totalBytesSent
-   @param totalBytesExpectedToSend
  */
 - (void)          URLSession:(NSURLSession *)session
                         task:(MendeleyNetworkUploadTask *)uploadTask

--- a/MendeleyKit/MendeleyKit/Networking/MendeleyNetworkProvider.h
+++ b/MendeleyKit/MendeleyKit/Networking/MendeleyNetworkProvider.h
@@ -33,15 +33,6 @@
 
 /**
    this method will GET HTTP method to download data from the server
-   @param fileURL
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param queryParameters this will be a set of query parameters
-   @param authenticationRequired
-   @param task
-   @param progressBlock
-   @param completionBlock
  */
 - (void)invokeDownloadToFileURL:(NSURL *)fileURL
                         baseURL:(NSURL *)baseURL
@@ -55,13 +46,6 @@
 
 /**
    uploading files method
-   @param fileURL
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param task
-   @param progressBlock
-   @param completionBlock
  */
 - (void)invokeUploadForFileURL:(NSURL * )fileURL
                        baseURL:(NSURL *)baseURL
@@ -77,12 +61,6 @@
    this method will GET HTTP method to download data from the server based on a
    complete link URL
    This method assumes that authentication is required
-   @param linkURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param queryParameters this will be a set of query parameters
-   @param task
-   @param completionBlock
  */
 - (void)         invokeGET:(NSURL *)linkURL
          additionalHeaders:(NSDictionary *)additionalHeaders
@@ -93,13 +71,13 @@
 
 /**
    this method will GET HTTP method to download data from the server
-   @param baseURL
-   @param api
+   @param baseURL base URL
+   @param api API path
    @param additionalHeaders any additional headers to be used in the request
    @param queryParameters this will be a set of query parameters
    @param authenticationRequired - some GET methods may not require authentication
-   @param task
-   @param completionBlock
+   @param task task
+   @param completionBlock completion block
  */
 - (void)         invokeGET:(NSURL *)baseURL
                        api:(NSString *)api
@@ -112,12 +90,6 @@
 /**
    this method will PUT HTTP method to upload & update data to the server.
    Used to update existing data on the server. All PUT methods are assumed to require authentication
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param bodyParameters
-   @param task
-   @param completionBlock
  */
 - (void)         invokePUT:(NSURL *)baseURL
                        api:(NSString *)api
@@ -131,13 +103,6 @@
 /**
  this method will PUT HTTP method to upload & update data to the server.
  Used to update existing data on the server. All PUT methods are assumed to require authentication
- @param baseURL
- @param api
- @param additionalHeaders any additional headers to be used in the request
- @param jsonData
- @param authenticationRequired
- @param task
- @param completionBlock
  */
 - (void)         invokePUT:(NSURL *)baseURL
                        api:(NSString *)api
@@ -150,14 +115,6 @@
 /**
    this method will POST HTTP method to upload data to the server.
     Use this to store data on the server.
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param bodyParameters a body consisting of NSString based key-value pairs
-   @param authenticationRequired
-   @param isJSON
-   @param task
-   @param completionBlock
  */
 - (void)        invokePOST:(NSURL *)baseURL
                        api:(NSString *)api
@@ -171,13 +128,6 @@
 /**
    this method will POST HTTP method to upload data to the server.
    Use this to store data on the server. All POST requests are assumed to require authentication
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param jsonData
-   @param authenticationRequired
-   @param task
-   @param completionBlock
  */
 - (void)        invokePOST:(NSURL *)baseURL
                        api:(NSString *)api
@@ -191,10 +141,6 @@
    this method will create a DELETE HTTP request.
    Use this to store data on the server.
    Delete methods require authentication
-   @param baseURL
-   @param api
-   @param task
-   @param completionBlock
  */
 - (void)      invokeDELETE:(NSURL *)baseURL
                        api:(NSString *)api
@@ -207,12 +153,6 @@
 /**
    this method will create a PATCH HTTP request.
    Use this to store data on the server
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param bodyParameters
-   @param task
-   @param completionBlock
  */
 - (void)       invokePATCH:(NSURL *)baseURL
                        api:(NSString *)api
@@ -225,12 +165,6 @@
 /**
    this method will create a PATCH HTTP request.
    Use this to update data on the server
-   @param baseURL
-   @param api
-   @param additionalHeaders any additional headers to be used in the request
-   @param jsonData
-   @param task
-   @param completionBlock
  */
 - (void)       invokePATCH:(NSURL *)baseURL
                        api:(NSString *)api
@@ -242,10 +176,6 @@
 
 /**
    this method will create a HEAD request.
-   @param baseURL
-   @param api
-   @param task
-   @param completionBlock
  */
 - (void)        invokeHEAD:(NSURL *)baseURL
                        api:(NSString *)api
@@ -255,15 +185,12 @@
 
 /**
    cancels a specific MendeleyTask
-   @param task
-   @param completionBlock
  */
 - (void) cancelTask:(MendeleyTask *)task
     completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    cancels ALL existing tasks
-   @param completionBlock
  */
 - (void)cancelAllTasks:(MendeleyCompletionBlock)completionBlock;
 

--- a/MendeleyKit/MendeleyKit/Networking/MendeleyOAuthProvider.h
+++ b/MendeleyKit/MendeleyKit/Networking/MendeleyOAuthProvider.h
@@ -41,9 +41,6 @@
 /**
    Some registered clients may be able to authenticate directly using username/password - instead of
    going through the login web-site.
-   @param username
-   @param password
-   @param completionBlock
  */
 - (void)authenticateWithUserName:(NSString *)username
                         password:(NSString *)password
@@ -54,8 +51,6 @@
    if unsuccessful. When nil, an error object will be provided.
    Threading note: authentication methods are used at login time, typically, from a view controller. It is assumed
    the method is being called on the main thread.
-   @param authenticationCode
-   @param completionBlock
  */
 - (void)authenticateWithAuthenticationCode:(NSString *)authenticationCode
                            completionBlock:(MendeleyOAuthCompletionBlock)completionBlock;
@@ -65,7 +60,7 @@
    if unsuccessful. When nil, an error object will be provided.
    Threading note: refresh maybe handled on main as well as background thread.
    @param credentials the current credentials (to be updated with the refresh)
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)refreshTokenWithOAuthCredentials:(MendeleyOAuthCredentials *)credentials
                          completionBlock:(MendeleyOAuthCompletionBlock)completionBlock;
@@ -76,7 +71,7 @@
  Threading note: refresh maybe handled on main as well as background thread.
  @param credentials the current credentials (to be updated with the refresh)
  @param task the task corresponding to the current operation
- @param completionBlock
+ @param completionBlock completion block
  */
 - (void)refreshTokenWithOAuthCredentials:(MendeleyOAuthCredentials *)credentials
                                     task:(MendeleyTask *)task
@@ -86,8 +81,6 @@
 
 /**
    checks if the url string given is the Redirect URL
-   @param urlString
-   @return YES if it is URL string
  */
 - (BOOL)urlStringIsRedirectURI:(NSString *)urlString;
 

--- a/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestHelper.h
+++ b/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestHelper.h
@@ -25,18 +25,17 @@
 #import "MendeleyCancellableRequest.h"
 
 @interface MendeleyNSURLRequestHelper : NSObject <NSURLConnectionDelegate, NSURLConnectionDataDelegate, MendeleyCancellableRequest>
+
 @property (nonatomic, copy) MendeleyResponseCompletionBlock completionBlock;
 @property (nonatomic, strong) MendeleyRequest *mendeleyRequest;
 @property (nonatomic, strong) NSURLConnection *thisConnection;
 @property (nonatomic, strong) NSMutableData *responseBody;
 @property (nonatomic, strong) NSHTTPURLResponse *response;
 @property (nonatomic, strong) MendeleyResponse *mendeleyResponse;
+
 /**
    initialises the connection with a MendeleyRequest. The MendeleyRequest object holds all the data we need
    to make the network connection
-   @param mendeleyRequest
-   @param completionBlock
-   @return an instance of MendeleyNSURLRequestHelper
  */
 - (id)initWithMendeleyRequest:(MendeleyRequest *)mendeleyRequest
               completionBlock:(MendeleyResponseCompletionBlock)completionBlock;
@@ -46,4 +45,5 @@
    @return BOOL if successful
  */
 - (BOOL)startRequest;
+
 @end

--- a/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestHelper.m
+++ b/MendeleyKit/MendeleyKit/Networking/NSURLConnection Provider/MendeleyNSURLRequestHelper.m
@@ -52,7 +52,10 @@
         return NO;
     }
     NSMutableURLRequest *urlRequest = self.mendeleyRequest.mutableURLRequest;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     self.thisConnection = [NSURLConnection connectionWithRequest:urlRequest delegate:self];
+#pragma GCC diagnostic pop
     if (nil == self.thisConnection)
     {
         if (nil != self.completionBlock)

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyQueryRequestParameters.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyQueryRequestParameters.h
@@ -44,7 +44,6 @@
 /**
    checks if a property with the provided name exists in the MendeleyQueryRequestParameters object
    and the subclass calling it
-   @param propertyName
  */
 - (BOOL)hasQueryParameterWithName:(NSString *)queryParameterName;
 @end
@@ -95,7 +94,6 @@
 @property (nonatomic, strong) NSString *source;
 @end
 
-
 @interface MendeleyCatalogParameters : MendeleyQueryRequestParameters
 @property (nonatomic, strong) NSString *arxiv;
 @property (nonatomic, strong) NSString *doi;
@@ -137,8 +135,3 @@
 @property (nonatomic, strong) NSNumber *skip_news_item_check;
 @property (nonatomic, strong) NSString *start_from;
 @end
-
-
-
-
-

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyRequest.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyRequest.h
@@ -32,9 +32,9 @@
 /**
    requestWithBaseURL
    Generates a basic container for MendeleyRequest
-   @param baseURL
-   @param api - if nil, then it is assumed that the baseURL gives the full path
-   @param requestType
+   @param baseURL base URL
+   @param api if nil, then it is assumed that the baseURL gives the full path
+   @param requestType request type
    @return a MendeleyRequest with a basic NSURLRequest property
  */
 + (MendeleyRequest *)requestWithBaseURL:(NSURL *)baseURL
@@ -44,9 +44,9 @@
 /**
    requestWithBaseURL
    Generates a basic authenticated container for MendeleyRequest
-   @param baseURL
-   @param api - if nil, then it is assumed that the baseURL gives the full path
-   @param requestType
+   @param baseURL base URL
+   @param api if nil, then it is assumed that the baseURL gives the full path
+   @param requestType request type
    @return a MendeleyRequest with a basic authenticated NSURLRequest property
  */
 + (MendeleyRequest *)authenticatedRequestWithBaseURL:(NSURL *)baseURL
@@ -62,7 +62,6 @@
 
 /**
    adds a header to the request
-   @param headerParameters
  */
 - (void)addHeaderWithParameters:(NSDictionary *)headerParameters;
 
@@ -70,8 +69,6 @@
    adds a list of parameters to the request body.
    Note: this method should only be used when adding JSON (or similar) request parameters to the body instead of
    header. It must NOT be used for uploading data
-   @param bodyParameters
-   @param isJSON
  */
 - (void)addBodyWithParameters:(NSDictionary *)bodyParameters isJSON:(BOOL)isJSON;
 

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyResponse.h
@@ -33,17 +33,12 @@
 @property (nonatomic, strong, readonly) NSURL *fileURL;
 /**
    initialises a MendeleyResponse object
-   @param urlResponse
-   @return MendeleyResponse object
  */
 
 + (MendeleyResponse *)mendeleyReponseForURLResponse:(NSURLResponse *)urlResponse;
 
 /**
    initialises a MendeleyResponse object with a file location (to be used for up/download)
-   @param urlResponse
-   @param fileURL
-   @return MendeleyResponse object
  */
 + (MendeleyResponse *)mendeleyReponseForURLResponse:(NSURLResponse *)urlResponse
                                             fileURL:(NSURL *)fileURL;
@@ -52,8 +47,8 @@
    used for deserialising response data. This method is used for cases where
    the body content is of type JSON.
    Don't use for binary data
-   @param rawResponseData
-   @param error
+   @param rawResponseData the raw response data
+   @param error the error
    @return YES if successful (error is nil) or NO otherwise
  */
 - (BOOL)deserialiseRawResponseData:(NSData *)rawResponseData error:(NSError **)error;
@@ -65,7 +60,7 @@
    a.) the error message returned from the server responds with gets passed into the error localizedDescription
    b.) the downloaded data - which contains the JSON error message - gets removed again
    @param fileURL the location to which the data have been downloaded
-   @param the error pointer returned from the server. If this is nil and the status code is NOT ok we will create and error here
+   @param error the error pointer returned from the server. If this is nil and the status code is NOT ok we will create and error here
    @return YES if successful (error is nil) or NO otherwise
  */
 - (BOOL)parseFailureResponseFromFileDownloadURL:(NSURL *)fileURL error:(NSError **)error;

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleySyncInfo.h
@@ -47,7 +47,6 @@
 
 /**
    creates a sync header out of an HTTP header
-   @param allHeaderFields
  */
 - (id)initWithAllHeaderFields:(NSDictionary *)allHeaderFields;
 @end

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyTask.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyTask.h
@@ -34,13 +34,13 @@
 
 
 /**
-   @param taskID
+   @param taskID task ID
    @return an instance of type MendeleyCancellationRequest
  */
 - (instancetype)initWithTaskID:(NSString *)taskID;
 
 /**
-   @param taskObject
+   @param requestObject object
    @return a cancellable task/request object
  */
 - (instancetype)initWithRequestObject:(id<MendeleyCancellableRequest>)requestObject;

--- a/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyTaskProvider.h
+++ b/MendeleyKit/MendeleyKit/Networking/Networking Objects/MendeleyTaskProvider.h
@@ -24,9 +24,6 @@
 @interface MendeleyTaskProvider : NSObject
 /**
    This creates a generic NSURLSessionTask
-   @param request
-   @param session
-   @param completionBlock
  */
 + (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
                                       session:(NSURLSession *)session
@@ -34,10 +31,6 @@
 
 /**
    This creates a download task
-   @param request
-   @param session
-   @param progressBlock
-   @param completionBlock
  */
 + (NSURLSessionDownloadTask *)downloadTaskWithRequest:(NSURLRequest *)request
                                               session:(NSURLSession *)session
@@ -46,10 +39,6 @@
 
 /**
    This creates a download task
-   @param request
-   @param session
-   @param progressBlock
-   @param completionBlock
  */
 + (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request
                                           session:(NSURLSession *)session

--- a/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthTokenHelper.h
+++ b/MendeleyKit/MendeleyKit/Networking/OAuth/MendeleyOAuthTokenHelper.h
@@ -24,7 +24,6 @@
 @interface MendeleyOAuthTokenHelper : NSObject
 /**
    refreshes and stores the access tokens
-   @param refreshBlock
  */
 + (void)refreshTokenWithRefreshBlock:(MendeleyCompletionBlock)refreshBlock;
 

--- a/MendeleyKit/MendeleyKit/Networking/Simple Network Provider/MendeleySimpleNetworkTask.h
+++ b/MendeleyKit/MendeleyKit/Networking/Simple Network Provider/MendeleySimpleNetworkTask.h
@@ -27,8 +27,6 @@
 
 /**
    creates a simple network task based on a NSURLSession object
-   @param sessionTask
-   @param completionBlock
  */
 - (instancetype)initWithSessionTask:(NSURLSessionTask *)sessionTask
                     completionBlock:(MendeleyResponseCompletionBlock)completionBlock;

--- a/MendeleyKit/MendeleyKit/Networking/Utils/MendeleyConnectionReachability.h
+++ b/MendeleyKit/MendeleyKit/Networking/Utils/MendeleyConnectionReachability.h
@@ -46,37 +46,31 @@
 
 /**
    this method check the availability of the Mendeley Server
-   @param completionBlock
  */
 - (void)mendeleyServerIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    this method check the availability of the Mendeley Documents Endpoint
-   @param completionBlock
  */
 - (void)mendeleyDocumentServiceIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    this method check the availability of the Mendeley Folders Endpoint
-   @param completionBlock
  */
 - (void)mendeleyFolderServiceIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    this method check the availability of the Mendeley Annotations Endpoint
-   @param completionBlock
  */
 - (void)mendeleyAnnotationServiceIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    this method check the availability of the Mendeley Groups Endpoint
-   @param completionBlock
  */
 - (void)mendeleyGroupServiceIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
    this method check the availability of the Mendeley Files Endpoint
-   @param completionBlock
  */
 - (void)mendeleyFileServiceIsReachableWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 

--- a/MendeleyKit/MendeleyKit/Networking/Utils/MendeleyURLBuilder.m
+++ b/MendeleyKit/MendeleyKit/Networking/Utils/MendeleyURLBuilder.m
@@ -67,7 +67,10 @@
     __block NSMutableString *httpBodyString = [NSMutableString string];
     NSString *addString = @"&";
     [parameters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
          NSString *urlEncodedValue = [value stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+#pragma GCC diagnostic pop
          urlEncodedValue = [urlEncodedValue stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
          [httpBodyString appendFormat:@"%@=%@", key, urlEncodedValue];
          [httpBodyString appendString:addString];

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyAnnotationsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyAnnotationsAPI.h
@@ -31,54 +31,35 @@
    Developers should use the methods provided in MendeleyKit rather
    than the methods listed here.
  */
-/**
-   @param annotationID
-   @param task
-   @param completionBlock
- */
 - (void)annotationWithAnnotationID:(NSString *)annotationID
                               task:(MendeleyTask *)task
                    completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
-   @param annotationID
-   @param task
-   @param completionBlock
  */
 - (void)deleteAnnotationWithID:(NSString *)annotationID
                           task:(MendeleyTask *)task
                completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
-   @param updatedMendeleyAnnotation
-   @param task
-   @param completionBlock
  */
 - (void)updateAnnotation:(MendeleyAnnotation *)updatedMendeleyAnnotation
                     task:(MendeleyTask *)task
          completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
+
 /**
-   @param mendeleyAnnotation
-   @param task
-   @param completionBlock
  */
 - (void)createAnnotation:(MendeleyAnnotation *)mendeleyAnnotation
                     task:(MendeleyTask *)task
          completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
-   @param linkURL
-   @param task
-   @param completionBlock
  */
 - (void)annotationListWithLinkedURL:(NSURL *)linkURL
                                task:(MendeleyTask *)task
                     completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   @param queryParameters
-   @param task
-   @param completionBlock
  */
 - (void)annotationListWithQueryParameters:(MendeleyAnnotationParameters *)queryParameters
                                      task:(MendeleyTask *)task
@@ -87,9 +68,6 @@
 /**
    This method returns a list of annotations IDs that were permanently deleted. The list of deleted IDs will be kept on
    the server for a limited period of time.
-   @param deletedSince the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)deletedAnnotationsSince:(NSDate *)deletedSince
                         groupID:(NSString *)groupID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyCommentsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyCommentsAPI.h
@@ -24,9 +24,6 @@
 
 /**
  Get expanded (i.e. with profile information) comments.
- @param newsItemID
- @param task
- @param completionBlock
  */
 
 - (void)expandedCommentsWithNewsItemID:(NSString *)newsItemID
@@ -35,9 +32,6 @@
 
 /**
  Get single comment.
- @param commentID
- @param task
- @param completionBlock
  */
 
 - (void)commentWithCommentID:(NSString *)commentID
@@ -46,9 +40,6 @@
 
 /**
  Create new comment.
- @param comment
- @param task
- @param completionBlock
  */
 
 - (void)createComment:(MendeleyComment *)comment
@@ -57,10 +48,6 @@
 
 /**
  Edit existing comment.
- @param commentID
- @param update
- @param task
- @param completionBlock
  */
 
 - (void)updateCommentWithCommentID:(NSString *)commentID
@@ -70,9 +57,6 @@
 
 /**
  Delete comment.
- @param commentID
- @param task
- @param completionBlock
  */
 
 - (void)deleteCommentWithCommentID:(NSString *)commentID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDatasetsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDatasetsAPI.h
@@ -34,9 +34,6 @@
 
 /**
 obtains a list of datasets for the first page.
-@param parameters the parameter set to be used in the request
-@param task
-@param completionBlock
 */
 - (void)datasetListWithQueryParameters:(MendeleyDatasetParameters *)queryParameters
                                   task:(MendeleyTask *)task
@@ -45,10 +42,6 @@ obtains a list of datasets for the first page.
 /**
  This method is only used when paging through a list of datasets on the server.
  All required parameters are provided in the linkURL, which should not be modified
-
- @param linkURL the full HTTP link to the dataset listings page
- @param task
- @param completionBlock
  */
 - (void)datasetListWithLinkedURL:(NSURL *)linkURL
                             task:(MendeleyTask *)task
@@ -56,9 +49,6 @@ obtains a list of datasets for the first page.
 
 /**
  obtains a dataset for given ID from the library
- @param datasetID
- @param task
- @param completionBlock
  */
 - (void)datasetWithDatasetID:(NSString *)datasetID
                         task:(MendeleyTask *)task
@@ -67,9 +57,6 @@ obtains a list of datasets for the first page.
 /**
  Creates a dataset based on the mendeley object model provided in the argument.
  The server will respond with the JSON data structure for the new object
- @param mendeleyDataset The dataset model
- @param task The networking task
- @param completionBlock The completion block
  */
 - (void)createDataset:(MendeleyDataset *)mendeleyDataset
                  task:(MendeleyTask *)task
@@ -93,8 +80,6 @@ obtains a list of datasets for the first page.
 
 /**
  obtains a list of licences that can be applied to datasets
- @param task
- @param completionBlock
  */
 - (void)datasetLicencesListWithTask:(MendeleyTask *)task
                     completionBlock:(MendeleyArrayCompletionBlock)completionBlock;

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.h
@@ -34,10 +34,6 @@
 /**
    This method is only used when paging through a list of documents on the server.
    All required parameters are provided in the linkURL, which should not be modified
-
-   @param linkURL the full HTTP link to the document listings page
-   @param task
-   @param completionBlock
  */
 - (void)documentListWithLinkedURL:(NSURL *)linkURL
                              task:(MendeleyTask *)task
@@ -45,9 +41,6 @@
 
 /**
    obtains a list of documents for the first page.
-   @param parameters the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)documentListWithQueryParameters:(MendeleyDocumentParameters *)queryParameters
                                    task:(MendeleyTask *)task
@@ -55,10 +48,6 @@
 
 /**
    obtains the first page of authored documents for another user.
-   @param profileID profile ID of the user
-   @param parameters the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)authoredDocumentListForUserWithProfileID:(NSString *)profileID
                                  queryParameters:(MendeleyDocumentParameters *)queryParameters
@@ -67,9 +56,6 @@
 
 /**
    obtains a document for given ID from the library
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)documentWithDocumentID:(NSString *)documentID
                           task:(MendeleyTask *)task
@@ -77,9 +63,6 @@
 
 /**
    This method returns a catalog document for a given catalog ID
-   @param catalogID
-   @param task
-   @param completionBlock
  */
 - (void)catalogDocumentWithCatalogID:(NSString *)catalogID
                                 task:(MendeleyTask *)task
@@ -87,9 +70,6 @@
 
 /**
    This method obtains a list of documents based on a filter. The filter should not be nil or empty
-   @param queryParameters
-   @param task
-   @param completionBlock
  */
 - (void)catalogDocumentWithParameters:(MendeleyCatalogParameters *)queryParameters
                                  task:(MendeleyTask *)task
@@ -97,9 +77,6 @@
 /**
    this creates a document based on the mendeley object model provided in the argument.
    The server will respond with the JSON data structure for the new object
-   @param mendeleyDocument
-   @param task
-   @param completionBlock
  */
 - (void)createDocument:(MendeleyDocument *)mendeleyDocument
                   task:(MendeleyTask *)task
@@ -107,9 +84,6 @@
 
 /**
    modify/update a document with ID. The server will return a JSON object with the updated data
-   @param updatedMendeleyDocument
-   @param task
-   @param completionBlock
  */
 - (void)updateDocument:(MendeleyDocument *)updatedMendeleyDocument
                   task:(MendeleyTask *)task
@@ -119,9 +93,6 @@
 /**
    this method will remove a document with given ID permanently. The document data cannot be retrieved.
    However, the user will be able to get a list of permanently removed IDs
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)deleteDocumentWithID:(NSString *)documentID
                         task:(MendeleyTask *)task
@@ -130,9 +101,6 @@
 /**
    This method will move a document of given ID into the trash on the server. Data in trash can be restored
    (as opposed to using the deleteDocumentWithID:completionBlock: method which permanently removes them)
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)trashDocumentWithID:(NSString *)documentID
                        task:(MendeleyTask *)task
@@ -141,9 +109,6 @@
 /**
    This method returns a list of document IDs that were permanently deleted. The list of deleted IDs will be kept on
    the server for a limited period of time.
-   @param deletedSince
-   @param task
-   @param completionBlock
  */
 - (void)deletedDocumentsSince:(NSDate *)deletedSince
                       groupID:(NSString *)groupID
@@ -154,10 +119,6 @@
    This method obtains a list for a given page link of 'trashed' documents
    based on a list of query parameters.
    All required parameters are provided in the linkURL, which should not be modified
-
-   @param linkURL the full HTTP link to the document listings page
-   @param task
-   @param completionBlock
  */
 - (void)trashedDocumentListWithLinkedURL:(NSURL *)linkURL
                                     task:(MendeleyTask *)task
@@ -166,9 +127,6 @@
 /**
    This method obtains a list for the 'first' page of 'trashed' documents
    based on a list of query parameters.
-   @param parameters the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)trashedDocumentListWithQueryParameters:(MendeleyDocumentParameters *)queryParameters
                                           task:(MendeleyTask *)task
@@ -178,9 +136,6 @@
    this method will remove a trashed document with given ID permanently.
    The document data cannot be retrieved.
    However, the user will be able to get a list of permanently removed IDs
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)deleteTrashedDocumentWithID:(NSString *)documentID
                                task:(MendeleyTask *)task
@@ -189,9 +144,6 @@
 /**
    this method will restore a trashed document.
    In essence this means the document must be retrieved using the /documents API
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)restoreTrashedDocumentWithID:(NSString *)documentID
                                 task:(MendeleyTask *)task
@@ -200,9 +152,6 @@
 
 /**
    obtains a document for given ID from the library
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)trashedDocumentWithDocumentID:(NSString *)documentID
                                  task:(MendeleyTask *)task
@@ -210,26 +159,18 @@
 
 /**
    Method to obtain the supported document types (e.g. journal, book etc)
-   @param task
-   @param completionBlock
  */
 - (void)documentTypesWithTask:(MendeleyTask *)task
               completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
    Method to obtain the supported identifier types (e.g. pmid, doi, arXiv etc)
-   @param task
-   @param completionBlock
  */
 - (void)identifierTypesWithTask:(MendeleyTask *)task
                 completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
    uploads a file from a location and returns a Mendeley Document in the completion handler
-   @param fileURL the location of the file
-   @param mimeType e.g. 'application/pdf'
-   @param task
-   @param completionBlock
  */
 - (void)documentFromFileWithURL:(NSURL *)fileURL
                        mimeType:(NSString *)mimeType
@@ -238,11 +179,12 @@
 
 /**
  Method clones document metadata to a new group/lib. The returned metadata contain the user document metadata including the document ID for the cloned document
- @param document the document to be cloned
- @param toGroup the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
- @param toFolder the target folder ID.
+ @param documentID the document to be cloned
+ @param groupID the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
+ @param folderID the target folder ID.
  @param profileID must be provided if the groupID is nil (this means clone to user library). Otherwise values are ignored
- @param completionBlock
+ @param task the task
+ @param completionBlock the completion block
  */
 - (void)cloneDocumentWithID:(NSString *)documentID
                     groupID:(NSString *)groupID
@@ -254,9 +196,10 @@
 /**
  Method clones files associated with a document from source to target.
  The target document must exist - otherwise the completionBlock will return an error
- @param document the source document with files
- @param toDocument the target document ID
- @param completionBlock
+ @param sourceDocumentID the source document with files
+ @param targetDocumentID the target document ID
+ @param task the task
+ @param completionBlock the completion block
  */
 - (void)cloneDocumentFiles:(NSString *)sourceDocumentID
           targetDocumentID:(NSString *)targetDocumentID
@@ -267,11 +210,12 @@
 /**
  Method clones document metadata to a new group/lib. It also clones any associated files from source to target document
  The returned metadata contain the user document metadata including the document ID for the cloned document
- @param document the document to be cloned
- @param toGroup the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
- @param toFolder the target folder ID.
+ @param documentID the document to be cloned
+ @param groupID the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
+ @param folderID the target folder ID.
  @param profileID must be provided if the groupID is nil (this means clone to user library). Otherwise values are ignored
- @param completionBlock
+ @param task the task
+ @param completionBlock the completion block
  */
 - (void)cloneDocumentAndFiles:(NSString *)documentID
                       groupID:(NSString *)groupID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFeedsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFeedsAPI.h
@@ -25,10 +25,6 @@
 /**
  This method is only used when paging through a list of documents on the server.
  All required parameters are provided in the linkURL, which should not be modified
- 
- @param linkURL the full HTTP link to the document listings page
- @param task
- @param completionBlock
  */
 - (void)feedListWithLinkedURL:(NSURL *)linkURL
                              task:(MendeleyTask *)task
@@ -36,9 +32,6 @@
 
 /**
  obtains a list of feeds for the first page.
- @param parameters the parameter set to be used in the request
- @param task
- @param completionBlock
  */
 - (void)feedListWithQueryParameters:(MendeleyFeedsParameters *)queryParameters
                                    task:(MendeleyTask *)task
@@ -46,9 +39,6 @@
 
 /**
  obtains feed with a given identifier
- @param feedID
- @param task
- @param completionBlock
  */
 - (void)feedWithId:(NSString *)feedId
               task:(MendeleyTask *)task
@@ -57,9 +47,6 @@
 
 /**
  likes a feed item.
- @param feedID
- @param task
- @param completionBlock
  */
 - (void)likeFeedWithID:(NSString *)feedID
                   task:(MendeleyTask *)task
@@ -67,9 +54,6 @@
 
 /**
  likes a feed item.
- @param feedID
- @param task
- @param completionBlock
  */
 - (void)unlikeFeedWithID:(NSString *)feedID
                     task:(MendeleyTask *)task
@@ -77,9 +61,6 @@
 
 /**
  List of users that like given item.
- @param feedID
- @param task
- @param completionBlock
  */
 
 - (void)likersForFeedWithID:(NSString *)feedID
@@ -89,9 +70,6 @@
 
 /**
  List of users that have shared given item.
- @param feedID
- @param task
- @param completionBlock
  */
 
 - (void)sharersForFeedWithID:(NSString *)feedID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFilesAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFilesAPI.h
@@ -33,9 +33,6 @@
 
 /**
    obtains a list of files for the first page.
-   @param parameters the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)fileListWithQueryParameters:(MendeleyFileParameters *)queryParameters
                                task:(MendeleyTask *)task
@@ -43,11 +40,6 @@
 
 /**
    obtains a file for given ID from the library
-   @param fileID
-   @param fileURL
-   @param task
-   @param progressBlock
-   @param completionBlock
  */
 - (void)fileWithFileID:(NSString *)fileID
              saveToURL:(NSURL *)fileURL
@@ -59,13 +51,13 @@
 /**
    this creates a file based on the mendeley object model provided in the argument.
    The server will respond with the JSON data structure for the new object
-   @param fileURL
+   @param fileURL the file URL
    @param filename the name of the file to be given when uploading. maybe different from fileURL
    @param contentType the contentType to be used. If none is provided, PDF will be taken
-   @param documentURLPath
-   @param task
-   @param progressBlock
-   @param completionBlock
+   @param documentURLPath the document path
+   @param task the task
+   @param progressBlock the progress block
+   @param completionBlock the completion block
  */
 - (void)           createFile:(NSURL *)fileURL
                      filename:(NSString *)filename
@@ -79,18 +71,12 @@
 /**
    this method will remove a file with given ID permanently. The file data cannot be retrieved.
    However, the user will be able to get a list of permanently removed IDs
-   @param documentID
-   @param task
-   @param completionBlock
  */
 - (void)deleteFileWithID:(NSString *)fileID
                     task:(MendeleyTask *)task
          completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
-   @param linkURL
-   @param task
-   @param completionBlock
  */
 - (void)fileListWithLinkedURL:(NSURL *)linkURL
                          task:(MendeleyTask *)task
@@ -99,9 +85,6 @@
 /**
    This method returns a list of files IDs that were permanently deleted. The list of deleted IDs will be kept on
    the server for a limited period of time.
-   @param deletedSince the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)deletedFilesSince:(NSDate *)deletedSince
                   groupID:(NSString *)groupID
@@ -114,9 +97,6 @@
    The objects are sorted by date with the most recent first.
    By default 20 items are returned.
    The number of records saved on the server is limited.
-   @param queryParameters the parameter set to be used in the request
-   @param task
-   @param completionBlock
  */
 - (void)recentlyReadWithParameters:(MendeleyRecentlyReadParameters *)queryParameters
                               task:(MendeleyTask *)task
@@ -127,9 +107,6 @@
    Any existing entry with a matching id if present is removed, and a new one is created.
    The new one is inserted into the list at a position determined by the
    current server time or at the time provided by the client if specified.
-   @param recentlyRead the recently read object to create
-   @param task
-   @param completionBlock
  */
 - (void)addRecentlyRead:(MendeleyRecentlyRead *)recentlyRead
                    task:(MendeleyTask *)task
@@ -142,9 +119,7 @@
    its position (page and vertical_position values) are updated.
    It is not brought to the top of the history.
    If there is no entry with matching id in the recent history, it returns an error.
-   @param recentlyRead the recently read object to update
-   @param task
-   @param completionBlock
+
    - (void)updateRecentlyRead:(MendeleyRecentlyRead *)recentlyRead
                       task:(MendeleyTask *)task
            completionBlock:(MendeleyObjectCompletionBlock)completionBlock;

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFoldersAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFoldersAPI.h
@@ -35,11 +35,7 @@
 
 
 /**
-   Obtain a list of documents belonging to a specific folder.
-   @param folderID
-   @param parameters
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of strings
+   Obtain a list of documents belonging to a specific folder (the array contained in the completionBlock will be an array of strings).
  */
 - (void)documentListFromFolderWithID:(NSString *)folderID
                           parameters:(MendeleyFolderParameters *)parameters
@@ -47,10 +43,7 @@
                      completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   this is getting the list of document IDs in a paged form
-   @param linkURL
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of strings
+   this is getting the list of document IDs in a paged form (the array contained in the completionBlock will be an array of strings)
  */
 - (void)documentListInFolderWithLinkedURL:(NSURL *)linkURL
                                      task:(MendeleyTask *)task
@@ -58,10 +51,6 @@
 
 /**
    Add a previously created document in a specific folder
-   @param mendeleyDocumentId
-   @param folderID
-   @param task
-   @param completionBlock
  */
 - (void)addDocument:(NSString *)mendeleyDocumentId
            folderID:(NSString *)folderID
@@ -70,9 +59,6 @@
 
 /**
    Create a folder
-   @param mendeleyFolder
-   @param task
-   @param completionBlock
  */
 - (void)createFolder:(MendeleyFolder *)mendeleyFolder
                 task:(MendeleyTask *)task
@@ -81,10 +67,6 @@
 /**
    This method is only used when paging through a list of folders on the server.
    All required parameters are provided in the linkURL, which should not be modified
-
-   @param linkURL the full HTTP link to the document listings page
-   @param task
-   @param completionBlock
  */
 - (void)folderListWithLinkedURL:(NSURL *)linkURL
                            task:(MendeleyTask *)task
@@ -92,9 +74,6 @@
 
 /**
    Obtain a list of folders for the logged-in user
-   @param queryParameters
-   @param task
-   @param completionBlock
  */
 - (void)folderListWithQueryParameters:(MendeleyFolderParameters *)queryParameters
                                  task:(MendeleyTask *)task
@@ -102,9 +81,6 @@
 
 /**
    Obtain a folder identified by the given folderID
-   @param folderID
-   @param task
-   @param completionBlock
  */
 - (void)folderWithFolderID:(NSString *)folderID
                       task:(MendeleyTask *)task
@@ -112,9 +88,6 @@
 
 /**
    Delete a folder identified by the given folderID
-   @param folderID
-   @param task
-   @param completionBlock
  */
 - (void)deleteFolderWithID:(NSString *)folderID
                       task:(MendeleyTask *)task
@@ -122,9 +95,6 @@
 
 /**
    Update a folder's name, or move it to a new parent
-   @param updatedFolder
-   @param task
-   @param completionBlock
  */
 - (void)updateFolder:(MendeleyFolder *)updatedFolder
                 task:(MendeleyTask *)task
@@ -132,10 +102,6 @@
 
 /**
    Delete a document identified by the given documentID and belonging to a folder identified by the given folderID
-   @param documentID
-   @param folderID
-   @param task
-   @param completionBlock
  */
 - (void)deleteDocumentWithID:(NSString *)documentID
             fromFolderWithID:(NSString *)folderID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFollowersAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyFollowersAPI.h
@@ -33,11 +33,7 @@
 
 
 /**
-   Obtain a list of followers for a given user.
-   @param profileID
-   @param parameters
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
+   Obtain a list of followers for a given user (the array contained in the completionBlock will be an array of MendeleyFollow objects).
  */
 - (void)followersForUserWithID:(NSString *)profileID
                     parameters:(MendeleyFollowersParameters *)parameters
@@ -45,11 +41,7 @@
                completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   Obtain a list of users followed by a given user.
-   @param profileID
-   @param parameters
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
+   Obtain a list of users followed by a given user (the array contained in the completionBlock will be an array of MendeleyFollow objects).
  */
 - (void)followedByUserWithID:(NSString *)profileID
                   parameters:(MendeleyFollowersParameters *)parameters
@@ -57,11 +49,7 @@
              completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   Obtain a list of pending followers for a given user.
-   @param profileID
-   @param parameters
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
+   Obtain a list of pending followers for a given user (the array contained in the completionBlock will be an array of MendeleyFollow objects).
  */
 - (void)pendingFollowersForUserWithID:(NSString *)profileID
                            parameters:(MendeleyFollowersParameters *)parameters
@@ -69,11 +57,7 @@
                       completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   Obtain a list of pending users followed by a given user.
-   @param profileID
-   @param parameters
-   @param task
-   @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
+   Obtain a list of pending users followed by a given user (the array contained in the completionBlock will be an array of MendeleyFollow objects).
  */
 - (void)pendingFollowedByUserWithID:(NSString *)profileID
                          parameters:(MendeleyFollowersParameters *)parameters
@@ -81,10 +65,7 @@
                     completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   Start following another user.
-   @param followedID
-   @param task
-   @param completionBlock - the object contained in the completionBlock will be a MendeleyFollow object
+   Start following another user (the object contained in the completionBlock will be a MendeleyFollow object).
  */
 - (void)followUserWithID:(NSString *)followedID
                     task:(MendeleyTask *)task
@@ -93,9 +74,6 @@
 
 /**
    Accept a pending follow request
-   @param requestID
-   @param task
-   @param completionBlock
  
  */
 - (void)acceptFollowRequestWithID:(NSString *)requestID
@@ -104,9 +82,6 @@
 
 /**
    Stop following a profile, cancel a follow request or reject a follow request
-   @param relationshipID
-   @param task
-   @param completionBlock
  */
 - (void)stopOrDenyRelationshipWithID:(NSString *)relationshipID
                           task:(MendeleyTask *)task
@@ -114,10 +89,6 @@
 
 /**
     Returns a follow relationship between two profiles if it exists.
-    @param followerID
-    @param followedID
-    @param task
-    @param completionBlock
  */
 
 - (void)followRelationshipBetweenFollower:(NSString *)followerID

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyGroupsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyGroupsAPI.h
@@ -31,10 +31,6 @@
  */
 
 /**
-   @param queryParameters
-   @param iconType
-   @param task
-   @param completionBlock
  */
 - (void)groupListWithQueryParameters:(MendeleyGroupParameters *)queryParameters
                             iconType:(MendeleyIconType)iconType
@@ -44,11 +40,6 @@
 /**
    This method is only used when paging through a list of groups on the server.
    All required parameters are provided in the linkURL, which should not be modified
-
-   @param linkURL the full HTTP link to the document listings page
-   @param iconType
-   @param task
-   @param completionBlock
  */
 - (void)groupListWithLinkedURL:(NSURL *)linkURL
                       iconType:(MendeleyIconType)iconType
@@ -56,10 +47,6 @@
                completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
 
 /**
-   @param groupID
-   @param iconType
-   @param task
-   @param completionBlock
  */
 - (void)groupWithGroupID:(NSString *)groupID
                 iconType:(MendeleyIconType)iconType
@@ -67,10 +54,6 @@
          completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
-   @param groupID
-   @param queryParameters
-   @param task
-   @param completionBlock
  */
 - (void)groupMemberListWithGroupID:(NSString *)groupID
                         parameters:(MendeleyGroupParameters *)queryParameters
@@ -82,9 +65,6 @@
 /**
    Obtain a list of groups where the logged in user is a member
    If provided, it will include the square icon for the group
-   @param queryParameters the parameters to be used in the API request
-   @param task
-   @param completionBlock the list of groups if found
  */
 - (void)groupListWithQueryParameters:(MendeleyGroupParameters *)queryParameters
                                 task:(MendeleyTask *)task
@@ -93,10 +73,6 @@
 /**
    This method is only used when paging through a list of groups on the server.
    All required parameters are provided in the linkURL, which should not be modified
-
-   @param linkURL the full HTTP link to the document listings page
-   @param task
-   @param completionBlock the list of groups if found
  */
 - (void)groupListWithLinkedURL:(NSURL *)linkURL
                           task:(MendeleyTask *)task
@@ -104,9 +80,6 @@
 
 /**
    Obtain details for the group identified by the given groupID
-   @param groupID the group UUID
-   @param task
-   @param completionBlock the group
  */
 - (void)groupWithGroupID:(NSString *)groupID
                     task:(MendeleyTask *)task
@@ -114,11 +87,7 @@
 
 
 /**
-   Obtains a group icon for a specified MendeleyGroup and icon type (maybe standard, square, original)
-   @param group
-   @param iconType
-   @param task
-   @param completionBlock returning the image data as NSData
+   Obtains a group icon for a specified MendeleyGroup and icon type (maybe standard, square, original) as NSData
  */
 - (void)groupIconForGroup:(MendeleyGroup *)group
                  iconType:(MendeleyIconType)iconType
@@ -127,10 +96,7 @@
 
 
 /**
-   Obtains a group icon based on the given link URL string
-   @param iconURLString
-   @param task
-   @param completionBlock returning the image data as NSData
+   Obtains a group icon based on the given link URL string as NSData
  */
 - (void)groupIconForIconURLString:(NSString *)iconURLString
                              task:(MendeleyTask *)task

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyMetadataAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyMetadataAPI.h
@@ -28,12 +28,6 @@
    Developers should use the methods provided in MendeleyKit rather
    than the methods listed here.
  */
-
-/**
-   @param queryParameters
-   @param task
-   @param completionBlock
- */
 - (void)metadataLookupWithQueryParameters:(MendeleyMetadataParameters *)queryParameters
                                      task:(MendeleyTask *)task
                           completionBlock:(MendeleyObjectCompletionBlock)completionBlock;

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyObjectAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyObjectAPI.h
@@ -36,17 +36,13 @@
 /**
    A general creator of MendeleyObjectAPI
    @param provider the network provider. By default the MendeleyDefaultNetworkProvider is taken. This is based on NSURLSession
-   @param baseURL
+   @param baseURL base URL
  */
 - (instancetype)initWithNetworkProvider:(id <MendeleyNetworkProvider> )provider
                                 baseURL:(NSURL *)baseURL;
 
 /**
    A convenience method that returns the link for the image of the choosen type passing a MendeleyPhoto Object
-   @param the photo object
-   @param iconType
-   @param task
-   @param error
  */
 
 - (NSString *)linkFromPhoto:(MendeleyPhoto *)photo

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyProfilesAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyProfilesAPI.h
@@ -30,28 +30,19 @@
  */
 /**
    Pulls the users profile
-   @param task
-   @param completionBlock
  */
 - (void)pullMyProfileWithTask:(MendeleyTask *)task
               completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
    Pulls the profile of a user with a given ID
-   @param profileID
-   @param task
-   @param completionBlock
  */
 - (void)pullProfile:(NSString *)profileID
                task:(MendeleyTask *)task
     completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
-   Obtains a profile icon for a specified MendeleyProfile and icon type (maybe standard, square, original)
-   @param profile
-   @param iconType
-   @param task
-   @param completionBlock returning the image data as NSData
+   Obtains a profile icon for a specified MendeleyProfile and icon type (maybe standard, square, original) as NSData
  */
 - (void)profileIconForProfile:(MendeleyProfile *)profile
                      iconType:(MendeleyIconType)iconType
@@ -60,10 +51,7 @@
 
 
 /**
-   Obtains a profile icon based on the given link URL string
-   @param iconURLString
-   @param task
-   @param completionBlock returning the image data as NSData
+   Obtains a profile icon based on the given link URL string as NSData
  */
 - (void)profileIconForIconURLString:(NSString *)iconURLString
                                task:(MendeleyTask *)task
@@ -74,9 +62,9 @@
    provided to be able to create a new profile
    first_name, last_name, email, password, main discipline, academic status
    Note: the email MUST be unique
-   @param profile - containing at least the 6 mandatory properties given above
-   @param task
-   @param completionBlock - the completionHandler.
+   @param profile containing at least the 6 mandatory properties given above
+   @param task the task
+   @param completionBlock the completionHandler.
  */
 - (void)createProfile:(MendeleyNewProfile *)profile
                  task:(MendeleyTask *)task
@@ -87,9 +75,9 @@
    If the user wants to update his password the following properties must be provided
    - password (i.e. the new password)
    - old_password (i.e the previous password to be replaced)
-   @param profile - the profile containing the updated parameters.
-   @param task
-   @param completionBlock - the completionHandler.
+   @param myProfile the profile containing the updated parameters.
+   @param task the task
+   @param completionBlock the completionHandler.
  */
 - (void)updateMyProfile:(MendeleyAmendmentProfile *)myProfile
                    task:(MendeleyTask *)task

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleySharesAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleySharesAPI.h
@@ -24,9 +24,6 @@
 
 /**
  shares a feed item.
- @param queryParameters
- @param task
- @param completionBlock
  */
 
 - (void)shareFeedWithQueryParameters:(MendeleySharesParameters *)queryParameters
@@ -35,9 +32,6 @@
 
 /**
  Shares a document.
- @param documentID
- @param task
- @param completionBlock
  */
 
 - (void)shareDocumentWithDocumentID:(NSString *)documentID
@@ -45,9 +39,6 @@
                     completionBlock:(MendeleyCompletionBlock)completionBlock;
 /**
  Shares a document.
- @param doi
- @param task
- @param completionBlock
  */
 
 - (void)shareDocumentWithDOI:(NSString *)doi
@@ -56,9 +47,6 @@
 
 /**
  Shares a document.
- @param scopus
- @param task
- @param completionBlock
  */
 
 - (void)shareDocumentWithScopus:(NSString *)scopus

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyUserPostsAPI.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyUserPostsAPI.h
@@ -24,9 +24,6 @@
 
 /**
  Creates a new user post.
- @param newPost
- @param task
- @param completionBlock
  */
 - (void)createUserPost:(MendeleyNewUserPost *)newPost
                   task:(MendeleyTask *)task
@@ -34,9 +31,6 @@
 
 /**
  Deletes a user post.
- @param postID
- @param task
- @param completionBlock
  */
 - (void)deleteUserPostWithPostID:(NSString *)postID
                             task:(MendeleyTask *)task
@@ -44,9 +38,6 @@
 
 /**
  Creates a new group post.
- @param groupPost
- @param task
- @param completionBlock
  */
 - (void)createGroupPost:(MendeleyNewGroupPost *)groupPost
                    task:(MendeleyTask *)task
@@ -55,9 +46,6 @@
 
 /**v
  Deletes a group post.
- @param postID
- @param task
- @param completionBlock
  */
 - (void)deleteGroupPostWithPostID:(NSString *)postID
                              task:(MendeleyTask *)task

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKit.h
@@ -59,7 +59,7 @@
    this method checks the validity of access and refresh token.
    E.g. if user changes password on another client, the refresh_token will expire
    In this case this method will return success == NO and error != nil in the completion block
-   @param completionBlock
+   @param completionBlock the completion block
    @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)checkAuthorisationStatusWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
@@ -139,8 +139,8 @@
 
 /**
    A convenience method to obtain the profile icon for a given MendeleyProfile object
-   @param profile
-   @param iconType
+   @param profile profile
+   @param iconType icon type
    @param completionBlock returning the image data as NSData
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -153,7 +153,7 @@
 /**
    Obtains a profile icon based on the given link URL string
    The URL string for a given icon is supplied with the MendeleyProfile metadata (see MendeleyPhoto property)
-   @param iconURLString
+   @param iconURLString icon URL
    @param completionBlock returning the image data as NSData
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -179,7 +179,7 @@
    If the user wants to update his password the following properties must be provided
    - password (i.e. the new password)
    - old_password (i.e the previous password to be replaced)
-   @param profile - the profile containing the updated parameters.
+   @param myProfile - the profile containing the updated parameters.
    @param completionBlock - the completionHandler.
    @return a cancellable MendeleyTask object
  */
@@ -190,11 +190,6 @@
 
 /**
  Upload a new original photo asset for my profile.
- @param fileURL
- @param contentType
- @param contentLenght
- @param progressBlock
- @param completionBlock
  */
 - (MendeleyTask *)uploadPhotoWithFile:(NSURL *)fileURL
                 contentType:(NSString *)contentType
@@ -230,7 +225,7 @@
 /**
    obtains the first page of authored documents for another user.
    @param profileID profile ID of the user
-   @param parameters the parameter set to be used in the request
+   @param queryParameters the parameter set to be used in the request
    @param completionBlock returning array of documents
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -383,7 +378,7 @@
    uploads a file from a location and returns a Mendeley Document in the completion handler
    @param fileURL the location of the file
    @param mimeType e.g. application/pdf
-   @param completionBlock
+   @param completionBlock the completion block
    @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)documentFromFileWithURL:(NSURL *)fileURL mimeType:(NSString *)mimeType completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
@@ -409,7 +404,7 @@
  @param groupID the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
  @param folderID the target folder ID.
  @param profileID must be provided if the groupID is nil (this means clone to user library). Otherwise values are ignored
- @param completionBlock
+ @param completionBlock the completion block
  */
 - (MendeleyTask *)cloneDocumentWithID:(NSString *)documentID
                               groupID:(NSString *)groupID
@@ -422,7 +417,7 @@
  The target document must exist - otherwise the completionBlock will return an error
  @param sourceDocumentID the source document with files
  @param targetDocumentID the target document ID
- @param completionBlock
+ @param completionBlock the completion block
  */
 - (MendeleyTask *)cloneDocumentFiles:(NSString *)sourceDocumentID
                     targetDocumentID:(NSString *)targetDocumentID
@@ -436,7 +431,7 @@
  @param groupID the target group ID. Use nil if you want to clone to the users' library. In this case the profile ID must be provided
  @param folderID the target folder ID.
  @param profileID must be provided if the groupID is nil (this means clone to user library). Otherwise values are ignored
- @param completionBlock
+ @param completionBlock the completion block
  */
 - (MendeleyTask *)cloneDocumentAndFiles:(NSString *)documentID
                                 groupID:(NSString *)groupID
@@ -565,7 +560,7 @@
    By default 20 items are returned.
    The number of records saved on the server is limited.
    @param queryParameters the parameter set to be used in the request
-   @param completionBlock
+   @param completionBlock the completion block
  */
 - (MendeleyTask *)recentlyReadWithParameters:(MendeleyRecentlyReadParameters *)queryParameters
                              completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
@@ -576,7 +571,7 @@
    The new one is inserted into the list at a position determined by the
    current server time or at the time provided by the client if specified.
    @param recentlyRead the recently read object to create
-   @param completionBlock
+   @param completionBlock the completion block
  */
 - (MendeleyTask *)addRecentlyRead:(MendeleyRecentlyRead *)recentlyRead
                   completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
@@ -589,7 +584,7 @@
    It is not brought to the top of the history.
    If there is no entry with matching id in the recent history, it returns an error.
    @param recentlyRead the recently read object to update
-   @param completionBlock
+   @param completionBlock the completion block
    - (MendeleyTask *)updateRecentlyRead:(MendeleyRecentlyRead *)recentlyRead
                      completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
  */
@@ -766,8 +761,8 @@
 
 /**
    A convenience method to obtain the group icon for a given MendeleyGroup object
-   @param group
-   @param iconType
+   @param group group
+   @param iconType icon type
    @param completionBlock returning the image data as NSData
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -779,7 +774,7 @@
 /**
    Obtains a group icon based on the given link URL string
    The URL string for a given icon is supplied with the MendeleyGroup metadata (see MendeleyPhoto property)
-   @param iconURLString
+   @param iconURLString icon URL
    @param completionBlock returning the image data as NSData
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -870,9 +865,8 @@
 #pragma mark - Followers
 /**
    Obtain a list of followers for a given user.
-   @param profileID
-   @param parameters
-   @param task
+   @param profileID profile ID
+   @param parameters parameters
    @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -882,9 +876,8 @@
 
 /**
    Obtain a list of users followed by a given user.
-   @param profileID
-   @param parameters
-   @param task
+   @param profileID profile ID
+   @param parameters parameters
    @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -894,9 +887,8 @@
 
 /**
    Obtain a list of pending followers for a given user.
-   @param profileID
-   @param parameters
-   @param task
+   @param profileID profile ID
+   @param parameters parameters
    @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -906,9 +898,8 @@
 
 /**
    Obtain a list of pending users followed by a given user.
-   @param profileID
-   @param parameters
-   @param task
+   @param profileID profile ID
+   @param parameters parameters
    @param completionBlock - the array contained in the completionBlock will be an array of MendeleyFollow objects
    @return a MendeleyTask object used for cancelling the operation
  */
@@ -918,8 +909,7 @@
 
 /**
  Start following another user.
- @param followedID
- @param task
+ @param followedID followed ID
  @param completionBlock - the object contained in the completionBlock will be a MendeleyFollow object
  @return a MendeleyTask object used for cancelling the operation
  */
@@ -928,8 +918,8 @@
 
 /**
  Accept a pending follow request
- @param requestID
- @param completionBlock
+ @param requestID request ID
+ @param completionBlock the completion block
  @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)acceptFollowRequestWithID:(NSString *)requestID
@@ -937,8 +927,8 @@
 
 /**
  Stop following a profile, cancel a follow request or reject a follow request
- @param relationshipID
- @param completionBlock
+ @param relationshipID relationship ID
+ @param completionBlock the completion block
  @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)stopOrDenyRelationshipWithID:(NSString *)relationshipID
@@ -946,9 +936,9 @@
 
 /**
  Returns a follow relationship between two profiles if it exists.
- @param followerID
- @param followedID
- @param completionBlock
+ @param followerID follower ID
+ @param followedID followed ID
+ @param completionBlock the completion block
  @return a MendeleyTask object used for cancelling the operation
  */
 
@@ -974,7 +964,7 @@
  All required parameters are provided in the linkURL, which should not be modified
  
  @param linkURL the full HTTP link to the document listings page
- @param completionBlock
+ @param completionBlock the completion block
  @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)feedListWithLinkedURL:(NSURL *)linkURL
@@ -982,8 +972,8 @@
 
 /**
  obtains a list of feeds for the first page.
- @param parameters the parameter set to be used in the request
- @param completionBlock
+ @param queryParameters the parameter set to be used in the request
+ @param completionBlock the completion block
  @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)feedListWithQueryParameters:(MendeleyFeedsParameters *)queryParameters
@@ -991,35 +981,24 @@
 
 /**
  obtains feed with a given identifier
- @param feedID
- @param completionBlock
- @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)feedWithId:(NSString *)feedId
    completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
  likes a feed item.
- @param feedID
- @param completionBlock
- @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)likeFeedWithID:(NSString *)feedID
        completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
  likes a feed item.
- @param feedID
- @param completionBlock
- @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)unlikeFeedWithID:(NSString *)feedID
          completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
  List of users that like given item.
- @param feedID
- @param completionBlock
  */
 - (MendeleyTask *)likersForFeedWithID:(NSString *)feedID
             completionBlock:(MendeleyArrayCompletionBlock)completionBlock;
@@ -1027,8 +1006,6 @@
 
 /**
  List of users that have shared given item.
- @param feedID
- @param completionBlock
  */
 
 - (MendeleyTask *)sharersForFeedWithID:(NSString *)feedID
@@ -1038,9 +1015,6 @@
 
 /**
  Creates a new user post.
- @param newPost
- @param task
- @param completionBlock
  */
 
 - (MendeleyTask *)createUserPost:(MendeleyNewUserPost *)newPost
@@ -1048,27 +1022,18 @@
 
 /**
  Deletes a user post.
- @param postID
- @param completionBlock
- @return a MendeleyTask object used for cancelling the operation
  */
 - (MendeleyTask *)deleteUserPostWithPostID:(NSString *)postID
                            completionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
  Creates a new group post.
- @param newGroupPost
- @param task
- @param completionBlock
  */
 - (MendeleyTask *)createGroupPost:(MendeleyNewGroupPost *)groupPost
                   completionBlock:(MendeleyObjectCompletionBlock)completionBlock;
 
 /**
  Deletes a group post.
- @param postID
- @param task
- @param completionBlock
  */
 - (MendeleyTask *)deleteGroupPostWithPostID:(NSString *)postID
                             completionBlock:(MendeleyCompletionBlock)completionBlock;
@@ -1091,9 +1056,6 @@
 
 /**
  Get expanded (i.e. with profile information) comments.
- @param newsItemID
- @param completionBlock
- @return task
  */
 
 - (MendeleyTask *)expandedCommentsWithNewsItemID:(NSString *)newsItemID
@@ -1101,9 +1063,6 @@
 
 /**
  Get single comment.
- @param commentID
- @param completionBlock
- @return task
  */
 
 - (MendeleyTask *)commentWithCommentID:(NSString *)commentID
@@ -1111,9 +1070,6 @@
 
 /**
  Create new comment.
- @param comment
- @param completionBlock
- @return task
  */
 
 - (MendeleyTask *)createComment:(MendeleyComment *)comment
@@ -1121,10 +1077,6 @@
 
 /**
  Edit existing comment.
- @param commentID
- @param update
- @param completionBlock
- @return task
  */
 
 - (MendeleyTask *)updateCommentWithCommentID:(NSString *)commentID
@@ -1133,9 +1085,6 @@
 
 /**
  Delete comment.
- @param commentID
- @param completionBlock
- @return task
  */
 
 - (MendeleyTask *)deleteCommentWithCommentID:(NSString *)commentID

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKitConfiguration.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKitConfiguration.h
@@ -59,7 +59,6 @@
  ** kMendeleyOAuthProviderKey    - the name of the class implementing the MendeleyOAuthDefaultProvider protocol
  ** kMendeleyNetworkProviderKey  - the name of the class implementing the MendeleyNetworkProvider protocol
  ** kMendeleyDocumentViewType    - the type of view to use while calling document related services. Value must be a NSString. Possible values are specified in the globals header.
-   @param configurationParameters
  */
 - (void)changeConfigurationWithParameters:(NSDictionary *)configurationParameters;
 

--- a/MendeleyKit/MendeleyKit/Public Interface/MendeleyKitHelper.h
+++ b/MendeleyKit/MendeleyKit/Public Interface/MendeleyKitHelper.h
@@ -47,16 +47,10 @@
    @name MendeleyKitHelper
    This class provides generic helper methods used in various API calls/callbacks
  */
-/**
-   @param delegate
-   @return an instance of the helper
- */
 - (instancetype)initWithDelegate:(id <MendeleyKitHelperDelegate> )delegate;
 
 /**
    checks whether a MendeleyResponse can be marked as successful or whether an error has occurred
-   @param response
-   @param error
  */
 - (BOOL)isSuccessForResponse:(MendeleyResponse *)response
                        error:(NSError **)error;
@@ -65,9 +59,9 @@
    Used in GET REST API calls: this gets a list of Mendeley Objects from the server
    @param objectTypeString e.g. MendeleyDocument
    @param apiString e.g. documents
-   @param queryParameters
+   @param queryParameters parameters
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)mendeleyObjectListOfType:(NSString *)objectTypeString
                              api:(NSString *)apiString
@@ -80,9 +74,9 @@
    Used in GET REST API calls. A specific call to get a list of ID strings from the server
    (e.g. /folders/{folderID}/documents)
    @param apiString e.g. documents
-   @param queryParameters
+   @param queryParameters parameters
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)mendeleyIDStringListForAPI:(NSString *)apiString
                         parameters:(NSDictionary *)queryParameters
@@ -93,10 +87,10 @@
 /**
    Used in GET REST API calls: obtains a single Mendeley Object
    @param objectTypeString e.g. MendeleyDocument
-   @param queryParameters
+   @param queryParameters parameters
    @param apiString e.g. documents
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)mendeleyObjectOfType:(NSString *)objectTypeString
                   parameters:(NSDictionary *)queryParameters
@@ -107,9 +101,6 @@
 
 /**
    This creates a new MendeleyObject on the server
-   @param mendeleyObject
-   @param apiString e.g. documents
-   @param completionBlock
  */
 - (void)createMendeleyObject:(MendeleySecureObject *)mendeleyObject
                          api:(NSString *)apiString
@@ -118,11 +109,11 @@
 
 /**
    Used in POST REST API calls
-   @param mendeleyObject
+   @param mendeleyObject object
    @param apiString e.g. documents
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
    @param objectTypeString e.g. MendeleyDocument
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)createMendeleyObject:(MendeleySecureObject *)mendeleyObject
                          api:(NSString *)apiString
@@ -134,9 +125,6 @@
 /**
    Used in PATCH REST API calls
    This updates an existing Mendeley Object on the server
-   @param updatedMendeleyObject
-   @param apiString e.g. documents
-   @param completionBlock
  */
 - (void)updateMendeleyObject:(MendeleySecureObject *)updatedMendeleyObject
                          api:(NSString *)apiString
@@ -146,10 +134,10 @@
 /**
    Used in PATCH REST API calls
    This updates an existing Mendeley Object on the server
-   @param mendeleyObject
+   @param updatedMendeleyObject object
    @param apiString e.g. documents
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)updateMendeleyObject:(MendeleySecureObject *)updatedMendeleyObject
                          api:(NSString *)apiString
@@ -161,11 +149,11 @@
 /**
    Used in PATCH REST API calls
    This updates an existing Mendeley Object on the server, returning the updated object in the completionBlock
-   @param mendeleyObject
+   @param updatedMendeleyObject object
    @param apiString e.g. documents
    @param additionalHeaders - this usually includes the Accept:"****+1.json" type header to accept API specific JSON responses
    @param objectTypeString e.g. MendeleyDocument
-   @param completionBlock
+   @param completionBlock completion block
  */
 - (void)updateMendeleyObject:(MendeleySecureObject *)updatedMendeleyObject
                          api:(NSString *)apiString
@@ -176,8 +164,6 @@
 
 /**
    Used in DELETE REST API calls. This deletes an object on the server
-   @param apiString e.g. documents
-   @param completionBlock
  */
 - (void)deleteMendeleyObjectWithAPI:(NSString *)apiString
                                task:(MendeleyTask *)task
@@ -187,8 +173,8 @@
    This is a specific GET request to download a file (typically a PDF file) to a specified location
    @param apiString e.g. documents
    @param fileURL the location to save the downloaded file in
-   @param progressBlock
-   @param completionBlock
+   @param progressBlock progress block
+   @param completionBlock completion block
  */
 - (void)downloadFileWithAPI:(NSString *)apiString
                   saveToURL:(NSURL *)fileURL

--- a/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.h
+++ b/MendeleyKit/MendeleyKit/UIKit/MendeleyLoginViewController.h
@@ -29,7 +29,6 @@
 
 /**
    initialises the login view controller with Client App details
-   @param completionBlock
  */
 
 - (instancetype)initWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
@@ -38,7 +37,6 @@
    custom initialisers
    The completion block BOOL variable is set to YES if login has been successful
    NO otherwise
-   @param completionBlock
  */
 - (instancetype)initWithCompletionBlock:(MendeleyCompletionBlock)completionBlock customOAuthProvider:(id<MendeleyOAuthProvider>)customOAuthProvider;
 

--- a/MendeleyKit/MendeleyKit/Utils/Activity Log/MendeleyLog.h
+++ b/MendeleyKit/MendeleyKit/Utils/Activity Log/MendeleyLog.h
@@ -71,16 +71,11 @@ typedef NS_ENUM (NSUInteger, MendeleyLogLevel)
 
 /**
  * Logs a message using the given parameters
-   @param domain
-   @param level
-   @param format (variable)
  */
 - (void)logMessageWithDomainString:(NSString *)domain level:(MendeleyLogLevel)level message:(NSString *)format, ...;
 
 /**
  * Logs an error message using the given error object
-   @param domain
-   @param error
  */
 - (void)logMessageWithDomainString:(NSString *)domain error:(NSError *)error;
 
@@ -96,7 +91,6 @@ typedef NS_ENUM (NSUInteger, MendeleyLogLevel)
 
 /**
  * Allow to the client to insert info about current device and user
-   @param deviceInfoDict
  */
 - (void)addUserInfoToPersistentLog:(NSDictionary *)deviceInfoDict;
 

--- a/MendeleyKit/MendeleyKit/Utils/Categories/NSDictionary+Merge.h
+++ b/MendeleyKit/MendeleyKit/Utils/Categories/NSDictionary+Merge.h
@@ -23,14 +23,11 @@
 @interface NSDictionary (Merge)
 /**
    merges 2 dictionaries. Used to combined e.g. query parameters
-   @param dict1
-   @param dict2
  */
 + (NSDictionary *)dictionaryByMerging:(NSDictionary *)dict1 with:(NSDictionary *)dict2;
 
 /**
    Merges this dictionary with values provided in the parameter
-   @param dict
  */
 - (NSDictionary *)dictionaryByMergingWith:(NSDictionary *)dict;
 

--- a/MendeleyKit/MendeleyKit/Utils/Categories/NSMutableArray+MaximumSize.h
+++ b/MendeleyKit/MendeleyKit/Utils/Categories/NSMutableArray+MaximumSize.h
@@ -24,15 +24,11 @@
 
 /**
    Ensures that an object is only added if the value is below maximumSize
-   @param object
-   @param maximumSize
  */
 - (void)addObject:(id)object maximumArraySize:(NSUInteger)maximumSize;
 
 /**
    Ensures that a list of objects is only added if the value is below maximumSize
-   @param objects
-   @param maximumSize
  */
 - (void)addObjectsFromArray:(NSArray *)objects maximumArraySize:(NSUInteger)maximumSize;
 

--- a/MendeleyKit/MendeleyKit/Utils/Error Management/MendeleyErrorManager.h
+++ b/MendeleyKit/MendeleyKit/Utils/Error Management/MendeleyErrorManager.h
@@ -32,7 +32,6 @@ typedef NS_ENUM (NSInteger, MendeleyReservedErrorCode) {
 @protocol MendeleyUserInfoProvider <NSObject>
 /**
    Returns the userInfo for a given error code
-   @param errorCode
  */
 - (NSDictionary *)userInfoWithErrorCode:(NSInteger)errorCode;
 
@@ -46,32 +45,23 @@ typedef NS_ENUM (NSInteger, MendeleyReservedErrorCode) {
 
 /**
  * add an error user info builder for a specific error domain. Raises an exception if the helper is nil, or if the errorDomain is nil or empty
-   @param helper
-   @param errorDomain
  */
 - (void)addUserInfoHelper:(id <MendeleyUserInfoProvider> )helper
               errorDomain:(NSString *)errorDomain;
 
 /**
  * remove the user info builder for a specific errorDomain. Does anything if the domain does not exists. Raises an exception if the errorDomain is nil or empty
-   @param errorDomain
  */
 - (void)removeUserInfoHelperWithErrorDomain:(NSString *)errorDomain;
 
 /**
  * create an NSError object whit a given errorDomain and errorCode. Raises an exception if the errorDomain is nil, empty, does not exist or the errorCode is not recognized as an error for the given domain
-   @param errorDomain
-   @param errorCode
-   @return NSError
  */
 - (NSError *)errorWithDomain:(NSString *)errorDomain
                         code:(NSInteger)errorCode;
 
 /**
  *  create an NSError object whose user info contains a list of the given errors. If one of the given errors is nil, the result error is the other one, nil if both are nil
-   @param originalError
-   @param secondError
-   @return NSError
  */
 - (NSError *)errorFromOriginalError:(NSError *)originalError
                               error:(NSError *)secondError;

--- a/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+Exceptions.h
+++ b/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+Exceptions.h
@@ -25,24 +25,18 @@
 /**
    asserts that an argument is not nil. If a required argument is nil, this is considered a fatal error, and the SDK will throw an exception.
    This will most likely cause the app to exit/crash.
-   @param argument
-   @param argumentName
  */
 + (void)assertArgumentNotNil:(id)argument argumentName:(NSString *)argumentName;
 
 /**
    asserts that an argument is not nil. If a required argument is nil, this is considered a fatal error, and the SDK will throw an exception.
    This will most likely cause the app to exit/crash.
-   @param argument
-   @param argumentName
  */
 + (void)assertStringArgumentNotNilOrEmpty:(NSString *)argument argumentName:(NSString *)argumentName;
 
 /**
    asserts that an argument is not nil. If a required argument is nil, this is considered a fatal error, and the SDK will throw an exception.
    This will most likely cause the app to exit/crash.
-   @param argument
-   @param argumentName
  */
 + (void)assertURLArgumentNotNilOrMissing:(NSURL *)argument argumentName:(NSString *)argumentName;
 

--- a/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+MendeleyError.h
+++ b/MendeleyKit/MendeleyKit/Utils/Error Management/NSError+MendeleyError.h
@@ -28,29 +28,29 @@
    provides convenience methods to create Mendeley specific errors
  */
 /**
-   @param code
-   @param localizedDescription
+   @param code code
+   @param localizedDescription localized description
    @return an error with default Mendeley SDK domain
  */
 + (instancetype)errorWithCode:(MendeleyErrorCode)code localizedDescription:(NSString *)localizedDescription;
 
 /**
-   @param code
+   @param code code
    @return an error object with default Mendeley Error domain
  */
 + (instancetype)errorWithCode:(MendeleyErrorCode)code;
 
 /**
-   @param response
-   @param url
+   @param response response
+   @param url URL
    @return an error with default Mendeley Error domain
  */
 + (instancetype)errorWithMendeleyResponse:(MendeleyResponse *)response requestURL:(NSURL *)url;
 
 /**
-   @param response
-   @param url
-   @param body
+   @param response response
+   @param url URL
+   @param body body
    @return an error with default Mendeley Error domain
  */
 + (instancetype)errorWithMendeleyResponse:(MendeleyResponse *)response requestURL:(NSURL *)url failureBody:(NSData *)body;

--- a/MendeleyKit/MendeleyKit/Utils/MendeleyBlockExecutor.h
+++ b/MendeleyKit/MendeleyKit/Utils/MendeleyBlockExecutor.h
@@ -33,45 +33,35 @@
  */
 
 /**
-   @param arrayCompletionBlock
  */
 - (instancetype)initWithArrayCompletionBlock:(MendeleyArrayCompletionBlock)arrayCompletionBlock;
 
 /**
-   @param stringArrayCompletionBlock
  */
 - (instancetype)initWithStringArrayCompletionBlock:(MendeleyStringArrayCompletionBlock)stringArrayCompletionBlock;
 
 /**
-   @param completionBlock
  */
 - (instancetype)initWithCompletionBlock:(MendeleyCompletionBlock)completionBlock;
 
 /**
-   @param objectCompletionBlock
  */
 - (instancetype)initWithObjectCompletionBlock:(MendeleyObjectCompletionBlock)objectCompletionBlock;
 
 /**
-   @param dictionaryCompletionBlock
  */
 - (instancetype)initWithDictionaryCompletionBlock:(MendeleyDictionaryResponseBlock)dictionaryCompletionBlock;
 
 /**
-   @param binaryDataCompletionBlock
  */
 - (instancetype)initWithBinaryDataCompletionBlock:(MendeleyBinaryDataCompletionBlock)binaryDataCompletionBlock;
 
 /**
-   @param oauthCompletionBlock
  */
 - (instancetype)initWithOAuthCompletionBlock:(MendeleyOAuthCompletionBlock)oauthCompletionBlock;
 
 /**
    executes the MendeleyArrayCompletionBlock on the main thread
-   @param array
-   @param syncInfo
-   @param error
  */
 - (void)executeWithArray:(NSArray *)array
                 syncInfo:(MendeleySyncInfo *)syncInfo
@@ -80,16 +70,11 @@
 
 /**
    executes the MendeleyCompletionBlock on the main thread
-   @param success
-   @param error
  */
 - (void)executeWithBool:(BOOL)success error:(NSError *)error;
 
 /**
    executes the MendeleyObjectCompletionBlock on the main thread
-   @param mendeleyObject
-   @param syncInfo
-   @param error
  */
 - (void)executeWithMendeleyObject:(MendeleySecureObject *)mendeleyObject
                          syncInfo:(MendeleySyncInfo *)syncInfo
@@ -97,23 +82,16 @@
 
 /**
    executes the MendeleyDictionaryCompletionBlock on the main thread
-   @param dictionary
-   @param error
  */
 - (void)executeWithDictionary:(NSDictionary *)dictionary error:(NSError *)error;
 
 /**
    executes the MendeleyDictionaryCompletionBlock on the main thread
-   @param binaryData
-   @param error
  */
 - (void)executeWithBinaryData:(NSData *)binaryData error:(NSError *)error;
 
-
 /**
    executes the MendeleyOAuthCompletionBlock on the main thread
-   @param credentials
-   @param error
  */
 - (void)executeWithCredentials:(MendeleyOAuthCredentials *)credentials error:(NSError *)error;
 

--- a/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyPerformanceMeter.h
+++ b/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyPerformanceMeter.h
@@ -39,7 +39,7 @@ typedef NS_ENUM (int, MendeleyPerformanceMeterConfiguration)
 
 /**
  creates a simple timer 
- @param timerName
+ @param timerName timer name
  @return string with timerID
  */
 - (NSString *)createSimpleTimerWithName:(NSString *)timerName;
@@ -51,43 +51,32 @@ typedef NS_ENUM (int, MendeleyPerformanceMeterConfiguration)
 
 /**
  stops and saves the time for timer with ID
- @param timerID
- @return string ??
  */
 - (NSString *)stopAndSaveSimpleTimerWithID:(NSString *)timerID;
 
 /**
  creates a new session with name
- @param sessionName
- @return session ID
  */
 - (NSString *)createNewSessionWithName:(NSString *)sessionName;
 
 /**
  adds a timer to a session with given ID
- @param timerName
- @param sessionID
- @return string timerID
  */
 - (NSString *)addTimerWithName:(NSString *)timerName ToSession:(NSString *)sessionID;
 
 /**
  starts the timer with timer/session ID
- @param timerID
- @param sessionID
  */
 - (void)startTimerWithID:(NSString *)timerID inSession:(NSString *)sessionID;
 
 /**
  stops the timer for timer/session ID
- @param timerID
- @param sessionID
  */
 - (void)stopTimerWithID:(NSString *)timerID inSession:(NSString *)sessionID;
 
 /**
  saves the timing report for a given session
- @param sessionID
+ @param sessionID session ID
  @return path to file saved
  */
 - (NSString *)saveReportAndFinalizeSession:(NSString *)sessionID;

--- a/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyPerformanceMeterSession.h
+++ b/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyPerformanceMeterSession.h
@@ -28,30 +28,24 @@
 
 /**
  returns a performance meter session with given name
- @param sessionName
  */
 + (MendeleyPerformanceMeterSession *)sessionWithName:(NSString *)sessionName;
 
 /**
  creates a timer with a gien name
- @param timerName
- @return timer Id
  */
 - (NSString *)createTimerWithName:(NSString *)timerName;
 
 /**
- @param timerID
  */
 - (void)startTimerWithID:(NSString *)timerID;
 
 /**
- @param timerID
  */
 - (void)stopTimerWithID:(NSString *)timerID;
 
 /**
  returns a report for a given timerID as dictionary
- @param timerID
  */
 - (NSDictionary *)reportWithTimerID:(NSString *)timerID;
 

--- a/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyTimer.h
+++ b/MendeleyKit/MendeleyKit/Utils/Performance/MendeleyTimer.h
@@ -58,7 +58,7 @@
 
 /**
  returns a timer for a given name
- @param name
+ @param name name
  @return the MendeleyTimer object if found
  */
 + (MendeleyTimer *)timerWithName:(NSString *)name;

--- a/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.h
+++ b/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.h
@@ -31,10 +31,6 @@
  */
 /**
    initialises the login view controller with Client App details
-   @param clientKey
-   @param clientSecret
-   @param redirectURI
-   @param completionBlock
  */
 
 - (instancetype)initWithClientKey:(NSString *)clientKey
@@ -46,10 +42,6 @@
    custom initialisers
    The completion block BOOL variable is set to YES if login has been successful
    NO otherwise
-   @param clientKey
-   @param clientSecret
-   @param redirectURI
-   @param completionBlock
  */
 - (instancetype)initWithClientKey:(NSString *)clientKey
                      clientSecret:(NSString *)clientSecret

--- a/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.m
+++ b/MendeleyKit/MendeleyKitOSX/AppKit/MendeleyLoginWindowController.m
@@ -59,7 +59,7 @@
               customOAuthProvider:(id<MendeleyOAuthProvider>)customOAuthProvider
 {
     NSRect frame = NSMakeRect(0, 0, 550, 450);
-    NSUInteger styleMask = NSTitledWindowMask | NSResizableWindowMask | NSClosableWindowMask;
+    NSUInteger styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskClosable;
     NSWindow *window = [[NSWindow alloc]
                         initWithContentRect:frame
                                   styleMask:styleMask


### PR DESCRIPTION
Fixes all the 500+ compilation warnings.

- Vast majority is about empty documentation (`empty paragraph passed to '@param' command [-Wdocumentation]`)
- Couple of ignoring deprecation warnings

```
'connectionWithRequest:delegate:' is deprecated: first deprecated in iOS 9.0 - Use NSURLSession (see NSURLSession.h) [-Wdeprecated-declarations]
'stringByAddingPercentEscapesUsingEncoding:' is deprecated: first deprecated in iOS 9.0 - Use -stringByAddingPercentEncodingWithAllowedCharacters: instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid. [-Wdeprecated-declarations]
```