### PR TITLE
Filter forbidden characters from filenames before upload

### DIFF
--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
@@ -459,12 +459,16 @@
 - (NSString *)safeFilenameFromURL:(NSURL *)fileURL
 {
     NSString *filename = [fileURL lastPathComponent];
-    // replace en dash with hyphen (they look similar, but only the hyphen is allowed)
+
+    // replace en/em dashes with hyphens (they look similar, but only the hyphen is allowed)
     filename = [filename stringByReplacingOccurrencesOfString:@"–" withString:@"-"];
+    filename = [filename stringByReplacingOccurrencesOfString:@"—" withString:@"-"];
+
     NSMutableCharacterSet *allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
-    [allowedCharacters addCharactersInString:@" .-"];
+    [allowedCharacters addCharactersInString:@" .-_"];
     NSCharacterSet *forbiddenCharacters = [allowedCharacters invertedSet];
     filename = [[filename componentsSeparatedByCharactersInSet:forbiddenCharacters] componentsJoinedByString:@""];
+
     return filename;
 }
 

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
@@ -464,6 +464,7 @@
     filename = [filename stringByReplacingOccurrencesOfString:@"–" withString:@"-"];
     filename = [filename stringByReplacingOccurrencesOfString:@"—" withString:@"-"];
 
+    // keep only alphanumeric characters, with a couple of exceptions “ .-_”
     NSMutableCharacterSet *allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
     [allowedCharacters addCharactersInString:@" .-_"];
     NSCharacterSet *forbiddenCharacters = [allowedCharacters invertedSet];

--- a/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
+++ b/MendeleyKit/MendeleyKit/Public Interface/API Interfaces/MendeleyDocumentsAPI.m
@@ -455,6 +455,19 @@
                           completionBlock:completionBlock];
 }
 
+// Removes forbidden characters from filename for upload
+- (NSString *)safeFilenameFromURL:(NSURL *)fileURL
+{
+    NSString *filename = [fileURL lastPathComponent];
+    // replace en dash with hyphen (they look similar, but only the hyphen is allowed)
+    filename = [filename stringByReplacingOccurrencesOfString:@"–" withString:@"-"];
+    NSMutableCharacterSet *allowedCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
+    [allowedCharacters addCharactersInString:@" .-"];
+    NSCharacterSet *forbiddenCharacters = [allowedCharacters invertedSet];
+    filename = [[filename componentsSeparatedByCharactersInSet:forbiddenCharacters] componentsJoinedByString:@""];
+    return filename;
+}
+
 - (void)documentFromFileWithURL:(NSURL *)fileURL
                        mimeType:(NSString *)mimeType
                            task:(MendeleyTask *)task
@@ -466,7 +479,7 @@
         mimeType = kMendeleyRESTRequestValuePDF;
     }
 
-    NSString *filename = [fileURL lastPathComponent];
+    NSString *filename = [self safeFilenameFromURL:fileURL];
     NSString *contentDisposition = [NSString stringWithFormat:@"%@; filename=\"%@\"", kMendeleyRESTRequestValueAttachment, filename];
 
     NSDictionary *header = @{ kMendeleyRESTRequestContentDisposition: contentDisposition,


### PR DESCRIPTION
Filters forbidden characters from filenames before upload.

There’s no definitive list of allowed/not allowed characters, so this pull request takes a conservative approach in keeping only a limited set of characters (alphanumeric + ` .-_`). It also replaces dashes with hyphens.