### PR TITLE
Deprecate MendeleyKit

### DIFF
--- a/MendeleyKit.podspec
+++ b/MendeleyKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "MendeleyKit"
-  s.version = "3.6.1"
+  s.version = "3.6.2"
   s.summary = "The Mendeley Objective-C/Swift client SDK."
   s.description = <<-DESC
                   # MendeleyKit
@@ -26,4 +26,5 @@ DESC
   s.macos.deployment_target = '10.13'
   s.macos.source_files = "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.macos.exclude_files = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'
+  s.deprecated = true
 end

--- a/MendeleyKitOSX.podspec
+++ b/MendeleyKitOSX.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "MendeleyKitOSX"
-  s.version           = "3.6.1"
+  s.version           = "3.6.2"
   s.summary           = "The Mendeley Objective C client SDK."
 
   s.description       = <<-DESC
@@ -18,11 +18,12 @@ DESC
 
   s.authors           = { "Mendeley iOS" => "ios@mendeley.com"}
   s.requires_arc      = true
-  s.source            = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.6.1" }
+  s.source            = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.6.2" }
   s.module_name       = "MendeleyKitOSX"
   s.osx.deployment_target = '10.13'
   s.source_files      = "MendeleyKit/MendeleyKitOSX/MendeleyKitOSX.h", "MendeleyKit/MendeleyKitOSX/AppKit", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.frameworks        = 'Foundation', 'CoreFoundation', 'AppKit', 'Security', 'WebKit', 'CoreServices'
   s.osx.exclude_files     = 'MendeleyKit/MendeleyKit/UIKit/*.{h,m,swift}'
   s.swift_version = '5.0'
+  s.deprecated = true
 end

--- a/MendeleyKitiOS.podspec
+++ b/MendeleyKitiOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "MendeleyKitiOS"
-  s.version = "3.6.1"
+  s.version = "3.6.2"
   s.summary      = "The Mendeley Objective C client SDK."
 
   s.description  = <<-DESC
@@ -18,9 +18,10 @@ DESC
 
   s.authors      = { "Mendeley iOS" => "ios@mendeley.com"}
   s.requires_arc  = true
-  s.source       = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.6.1" }
+  s.source       = { :git => "https://github.com/Mendeley/mendeleykit.git", :tag => "3.6.2" }
   s.module_name = "MendeleyKitiOS"
   s.ios.deployment_target = '11.0'
   s.source_files  = "MendeleyKit/MendeleyKitiOS/MendeleyKitiOS.h", "MendeleyKit/MendeleyKit/*.h", "MendeleyKit/MendeleyKit/**/*.{h,m,swift}"
   s.swift_version = '5.0'
+  s.deprecated = true
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# MendeleyKit — the Mendeley SDK for Objective-C/Swift #
+# [DEPRECATED] MendeleyKit — the Mendeley SDK for Objective-C/Swift #
 
-Latest Release: December 2020 (3.6.1)
+This framework is deprecated and no longer supported.
+
+Final Release: February 2021 (3.6.2)
 
 ## About MendeleyKit 3.x ##
 MendeleyKit is a standalone framework providing convenience methods


### PR DESCRIPTION
Marking MendeleyKit as deprecated by:

1. Adding a deprecation note to the README file
2. Marking the cocoapods as deprecated in the podspec files.